### PR TITLE
Issue #72: deleted incorrect instructions

### DIFF
--- a/cloud_config/compute/cloud_servers_product_concepts/metadata/set_metadata.rst
+++ b/cloud_config/compute/cloud_servers_product_concepts/metadata/set_metadata.rst
@@ -21,11 +21,4 @@ the key you want to remove:
 xxxxxxxx insert screenshot of deleting a metadata field, possibly the
 one we used earlier as an example.
 
-After a metadata field is deleted, it cannot be recovered, unless you
-have a stored image of the server. If you have a stored image of the
-server, you may be able to
-
-* rebuild the server from the image and retrieve the metadata field
-
-* view the image properties of the image and look for fields prefixed
-  with instance
+After a metadata field is deleted, it cannot be recovered.


### PR DESCRIPTION
Server metadata is not copied onto on-demand images of a server, so
looking at an image to find server metadata you've deleted by mistake
won't work.