### PR TITLE
improve order of API-related pages in toctree

### DIFF
--- a/cloud_interfaces/API/APIdirect.rst
+++ b/cloud_interfaces/API/APIdirect.rst
@@ -1,0 +1,62 @@
+.. _APIdirect:
+
+-----------------
+Direct API access
+-----------------
+Each of our cloud services exposes an API which can be leveraged for
+low-level integration with the service. 
+Rackspace APIs, 
+like OpenStack APIs, 
+are Representational State Transfer (REST) APIs, 
+meaning they are is logically
+structured, stateless, and scalable (among other properties). 
+
+For most use cases, we recommend 
+working with the guidance of an SDK
+rather than integrating directly with an API. 
+We have documented basic
+functions for many APIs in many popular programming languages in
+quickstart guides for developers at
+https://developer.rackspace.com/docs/. However, knowing the API
+structure and being able to make direct, manual calls to the API is a
+powerful tool for understanding and managing the Rackspace Cloud
+infrastructure.
+
+The API Developer Guide for each service is available at
+http://docs.rackspace.com/; the same API operations are also listed
+in a 
+combined reference at http://api.rackspace.com/.
+
+Some of the most common ways to directly interact with APIs are:
+
+* command line tools, 
+  such as 
+  `cURL <http://curl.haxx.se/>`__
+
+* browser extensions, 
+  such as 
+  `Postman for Chrome <https://www.getpostman.com/>`__
+
+* utilities for specific operating systems,  
+  such as those listed in your app store or directory 
+  under *REST client*
+
+For each service that offers a public API, 
+Rackspace publishes at least two technical documents:
+ 
+* `API Developer Guide <http://docs.rackspace.com>`__: 
+  reference material *describing* API requests and sample responses
+   
+* `API Getting Started Guide <http://docs.rackspace.com>`__: 
+  tutorial material *demonstrating* simple interactions
+  with the API 
+ 
+We published these API documents primarily to support readers who are 
+already experienced with RESTful APIs in other contexts and 
+are seeking details specifically about Rackspace's APIs. 
+We don't publish a beginner-level API tutorial. 
+However, REST is widely used and introductory material is
+readily available. 
+If you wish to work with our APIs and this would be your first
+experience with RESTful APIs, 
+begin with :ref:`setup_API`.

--- a/cloud_interfaces/API/SDK.rst
+++ b/cloud_interfaces/API/SDK.rst
@@ -1,0 +1,32 @@
+.. _SDK:
+
+--------------------------------
+Software Development Kits (SDKs)
+--------------------------------
+Software development kits provide
+easy to use, language-specific interfaces 
+for accessing and integrating
+APIs into your applications and workflows. 
+Often these libraries also
+abstract the functionality required to support your applications and
+workloads across multiple cloud endpoints or providers.
+
+Rackspace supports SDKs for the following languages:
+
+* Go
+
+* Java
+
+* .Net
+
+* Node.js
+
+* PHP
+
+* Python
+
+* Ruby
+
+You can find links to all the Rackspace-supported SDKs, with
+installation instructions, guidance, tutorials, and more for each, at
+https://developer.rackspace.com/sdks/.

--- a/cloud_interfaces/API/cloudblockstorage_API.rst
+++ b/cloud_interfaces/API/cloudblockstorage_API.rst
@@ -1,8 +1,8 @@
 .. _cloudblockstorage_API:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------
 Cloud Block Storage and SDKs and APIs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------
 When you begin writing your own software
 to interact with Cloud Block Storage, 
 you may benefit from investing some time to learn about 
@@ -12,9 +12,9 @@ and how SDKs and APIs are documented at Rackspace.
 
 .. _cloudblockstorage_APIinvestigation:
 
--------------------------------------
++++++++++++++++++++++++++++++++++++++
 Cloud Block Storage API investigation
--------------------------------------
++++++++++++++++++++++++++++++++++++++
 Using an API, 
 you can write software to automate functions that could otherwise 
 be performed manually by a person logged into the Cloud Control Panel. 
@@ -56,9 +56,9 @@ can help you to plan the easiest way to develop your software.
 
 .. _cloudblockstorage_APIdemonstration:
 
--------------------------------------
++++++++++++++++++++++++++++++++++++++
 Cloud Block Storage API demonstration
--------------------------------------
++++++++++++++++++++++++++++++++++++++
 Using the process suggested at 
 :ref:`cloudblockstorage_APIinvestigation`, 
 here is an example of how you can plan 
@@ -66,7 +66,7 @@ and then write your own software to perform one simple task:
 list all your Cloud Block Storage volumes. 
 
 Learn about Cloud Block Storage in the Cloud Control Panel  
-==========================================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 When you login to the 
 `Cloud Control Panel <https://mycloud.rackspace.com/>`__, 
 your session begins with information about your Cloud Servers.
@@ -103,7 +103,7 @@ you can see
 .. include:: note-chrome-devtools.rst
 
 Learn about Cloud Block Storage in API documentation
-====================================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In the combined API reference, 
 api.rackspace.com, 
 you can see all available API operations for all cloud services. 
@@ -147,7 +147,7 @@ you can see an example of
 <http://docs.rackspace.com/cbs/api/v1.0/cbs-getting-started/content/Listing_volumes_d1e060.html>`__. 
 
 Learn about Cloud Block Storage in SDK QuickStart
-=================================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In the SDK QuickStart for Cloud Block Storage, 
 https://developer.rackspace.com/docs/cloud-block-storage/getting-started/,
 you can see some of the same steps that are documented in 
@@ -173,7 +173,7 @@ and click *PHP*.
          publish an SDK QuickStart.
 
 Use SDK to help you write and run code to interact with Cloud Block Storage
-===========================================================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The SDK QuickStart demonstrates a few basic requests; 
 for more detailed guidance, 
 perhaps enough to walk you through exactly the steps required 

--- a/cloud_interfaces/API/cloudimages_API.rst
+++ b/cloud_interfaces/API/cloudimages_API.rst
@@ -1,8 +1,8 @@
 .. _cloudimages_API:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 Cloud Images and SDKs and APIs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
 When you begin writing your own software
 to interact with Cloud Images, 
 you may benefit from investing some time to learn about 
@@ -12,9 +12,9 @@ and how SDKs and APIs are documented at Rackspace.
 
 .. _cloudimages_APIinvestigation:
 
-------------------------------
+++++++++++++++++++++++++++++++
 Cloud Images API investigation
-------------------------------
+++++++++++++++++++++++++++++++
 Using an API, 
 you can write software to automate functions that could otherwise 
 be performed manually by a person logged into the Cloud Control Panel. 
@@ -56,9 +56,9 @@ can help you to plan the easiest way to develop your software.
 
 .. _cloudimages_APIdemonstration:
 
-------------------------------
+++++++++++++++++++++++++++++++
 Cloud Images API demonstration
-------------------------------
+++++++++++++++++++++++++++++++
 Using the process suggested at 
 :ref:`cloudimages_APIinvestigation`, 
 here is an example of how you can plan 
@@ -66,7 +66,7 @@ and then write your own software to perform one simple task:
 list all your Cloud Images. 
 
 Learn about Cloud Images in the Cloud Control Panel  
-====================================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 When you login to the 
 `Cloud Control Panel <https://mycloud.rackspace.com/>`__, 
 your session begins with information about your Cloud Servers.
@@ -98,7 +98,7 @@ you can see
 .. include:: note-chrome-devtools.rst
 
 Learn about Cloud Images in API documentation
-=============================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In the combined API reference, 
 api.rackspace.com, 
 you can see all available API operations for all cloud services. 
@@ -139,7 +139,7 @@ you can see an example of
 <http://docs.rackspace.com/images/api/v2/ci-gettingstarted/content/list-images.html>`__. 
 
 Learn about Cloud Images in SDK QuickStart
-==========================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In the SDK QuickStart for Cloud Images, 
 https://developer.rackspace.com/docs/cloud-images/getting-started/,
 you can see some of the same steps that are documented in 
@@ -165,7 +165,7 @@ and click *python*.
          publish an SDK QuickStart.
 
 Use SDK to help you write and run code to interact with Cloud Images
-====================================================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The SDK QuickStart demonstrates a few basic requests; 
 for more detailed guidance, 
 perhaps enough to walk you through exactly the steps required 

--- a/cloud_interfaces/API/cloudnetworks_API.rst
+++ b/cloud_interfaces/API/cloudnetworks_API.rst
@@ -1,8 +1,8 @@
 .. _cloudnetworks_API:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 Cloud Networks and SDKs and APIs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 When you begin writing your own software
 to interact with Cloud Networks, 
 you may benefit from investing some time to learn about 
@@ -12,9 +12,9 @@ and how SDKs and APIs are documented at Rackspace.
 
 .. _cloudnetworks_APIinvestigation:
 
--------------------------------------
+++++++++++++++++++++++++++++++++
 Cloud Networks API investigation
--------------------------------------
+++++++++++++++++++++++++++++++++
 Using an API, 
 you can write software to automate functions that could otherwise 
 be performed manually by a person logged into the Cloud Control Panel. 
@@ -56,9 +56,9 @@ can help you to plan the easiest way to develop your software.
 
 .. _cloudnetworks_APIdemonstration:
 
---------------------------------
+++++++++++++++++++++++++++++++++
 Cloud Networks API demonstration
---------------------------------
+++++++++++++++++++++++++++++++++
 Using the process suggested at 
 :ref:`cloudnetworks_APIinvestigation`, 
 here is an example of how you can plan 
@@ -66,7 +66,7 @@ and then write your own software to perform one simple task:
 list all your Cloud Networks. 
 
 Learn about Cloud Networks in the Cloud Control Panel  
-=====================================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 When you login to the 
 `Cloud Control Panel <https://mycloud.rackspace.com/>`__, 
 your session begins with information about your Cloud Servers.
@@ -97,7 +97,7 @@ you can see
 .. include:: note-chrome-devtools.rst
 
 Learn about Cloud Block Storage in API documentation
-====================================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In the combined API reference, 
 api.rackspace.com, 
 you can see all available API operations for all cloud services. 
@@ -141,7 +141,7 @@ you can see an example of
 <http://docs.rackspace.com/networks/api/v2/cn-gettingstarted/content/neutron_list_networks_curl.html>`__. 
 
 Learn about Cloud Networks in SDK QuickStart
-============================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In the SDK QuickStart for Cloud Networks, 
 https://developer.rackspace.com/docs/cloud-networks/getting-started/,
 you can see some of the same steps that are documented in 
@@ -167,7 +167,7 @@ and click *Java*.
          publish an SDK QuickStart.
          
 Use SDK to help you write and run code to interact with Cloud Networks
-======================================================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The SDK QuickStart demonstrates a few basic requests; 
 for more detailed guidance, 
 perhaps enough to walk you through exactly the steps required 

--- a/cloud_interfaces/API/cloudservers_API.rst
+++ b/cloud_interfaces/API/cloudservers_API.rst
@@ -1,8 +1,8 @@
 .. _cloudservers_API:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 Cloud Servers and SDKs and APIs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 When you begin writing your own software
 to interact with Cloud Servers, 
 you may benefit from investing some time to learn about 
@@ -12,9 +12,9 @@ and how SDKs and APIs are documented at Rackspace.
 
 .. _cloudservers_APIinvestigation:
 
--------------------------------
++++++++++++++++++++++++++++++++
 Cloud Servers API investigation
--------------------------------
++++++++++++++++++++++++++++++++
 Using an API, 
 you can write software to automate functions that could otherwise 
 be performed manually by a person logged into the Cloud Control Panel. 
@@ -82,9 +82,9 @@ available within the broader Rackspace portfolio include:
 
 .. _cloudservers_APIdemonstration:
 
--------------------------------
++++++++++++++++++++++++++++++++
 Cloud Servers API demonstration
--------------------------------
++++++++++++++++++++++++++++++++
 Using the process suggested at 
 :ref:`cloudservers_APIinvestigation`, 
 here is an example of how you can plan 
@@ -92,7 +92,7 @@ and then write your own software to perform one simple task:
 list all your Cloud Servers. 
 
 Learn about Cloud Servers in the Cloud Control Panel  
-====================================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 When you login to the 
 `Cloud Control Panel <https://mycloud.rackspace.com/>`__, 
 your session begins with a list of all your Cloud Servers. 
@@ -108,7 +108,7 @@ for tag, status, image, flavor, and type.
 .. include:: note-chrome-devtools.rst
 
 Learn about Cloud Servers in API documentation
-==============================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In the combined API reference, 
 api.rackspace.com, 
 you can see all available API operations for all cloud services. 
@@ -162,7 +162,7 @@ demonstrates
 <http://docs.rackspace.com/servers/api/v2/cs-gettingstarted/content/curl_list_servers.html>`__. 
 
 Learn about Cloud Servers in SDK QuickStart
-===========================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In the SDK QuickStart for Cloud Servers, 
 https://developer.rackspace.com/docs/cloud-servers/getting-started/,
 you can see some of the same steps that are documented in 
@@ -188,7 +188,7 @@ and click *python*.
          publish an SDK QuickStart.
 
 Use SDK to help you write and run code to interact with Cloud Servers
-=====================================================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The SDK QuickStart demonstrates a few basic requests; 
 for more detailed guidance, 
 perhaps enough to walk you through exactly the steps required 

--- a/cloud_interfaces/API/devopstools.rst
+++ b/cloud_interfaces/API/devopstools.rst
@@ -1,0 +1,19 @@
+.. _devopstools:
+
+------------
+DevOps tools
+------------
+If you use popular DevOps tools such as Knife, Vagrant, Ansible, and
+Salt, you may be interested in plugins (official or unofficial) 
+that improve the abilities of 
+these automation frameworks to support cloud-based operations. 
+Sources of more information about these
+plugins include:
+
+* Knife: https://github.com/opscode/knife-rackspace
+
+* Vagrant: https://github.com/mitchellh/vagrant-rackspace
+
+* Ansible: http://docs.ansible.com/guide_rax.html
+
+* Salt: http://docs.saltstack.com/en/latest/topics/cloud/rackspace.html

--- a/cloud_interfaces/API/index.rst
+++ b/cloud_interfaces/API/index.rst
@@ -5,133 +5,33 @@ API & SDK: Developer and DevOps tools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you write applications that are tightly integrated with 
 the Rackspace cloud 
-you may find that the Control Panel and CLIs are not ideal for
+you may find that 
+clicking to choose options in the Cloud Control Panel 
+and typing to issue commands with CLIs 
+are not ideal for
 your purposes. 
+
 If you develop or distribute applications for your customers, 
 or if you wish to heavily automate operation of your 
 cloud infrastructure,
 you may need to interact with cloud services 
 through one of the many available Software Development Kits 
 or by 
-direct API access
+direct API access.
 
-.. _cloud_interfaces_API-SDK:
-
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Software Development Kits (SDKs)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Software development kits provide
-easy to use, language-specific interfaces 
-for accessing and integrating
-APIs into your applications and workflows. 
-Often these libraries also
-abstract the functionality required to support your applications and
-workloads across multiple cloud endpoints or providers.
-
-Rackspace supports SDKs for the following languages:
-
-* Go
-
-* Java
-
-* .Net
-
-* Node.js
-
-* PHP
-
-* Python
-
-* Ruby
-
-You can find links to all the Rackspace-supported SDKs, with
-installation instructions, guidance, tutorials, and more for each, at
-https://developer.rackspace.com/sdks/.
-
-.. _cloud_interfaces_API-APIdirect:
-
-^^^^^^^^^^^^^^^^^
-Direct API access
-^^^^^^^^^^^^^^^^^
-Each of our cloud services exposes an API which can be leveraged for
-low-level integration with the service. 
-Rackspace APIs, 
-like OpenStack APIs, 
-are Representational State Transfer (REST) APIs, 
-meaning they are is logically
-structured, stateless, and scalable (among other properties). 
-
-For most use cases, we recommend 
-working with the guidance of an SDK
-rather than integrating directly with an API. 
-We have documented basic
-functions for many APIs in many popular programming languages in
-quickstart guides for developers at
-https://developer.rackspace.com/docs/. However, knowing the API
-structure and being able to make direct, manual calls to the API is a
-powerful tool for understanding and managing the Rackspace Cloud
-infrastructure.
-
-The API Developer Guide for each service is available at
-http://docs.rackspace.com/; the same API operations are also listed
-in a 
-combined reference at http://api.rackspace.com/.
-
-Some of the most common ways to directly interact with APIs are:
-
-* command line tools, 
-  such as 
-  `cURL <http://curl.haxx.se/>`__
-
-* browser extensions, 
-  such as 
-  `Postman for Chrome <https://www.getpostman.com/>`__
-
-* utilities for specific operating systems,  
-  such as those listed in your app store or directory 
-  under *REST client*
-
-For each service that offers a public API, 
-Rackspace publishes at least two technical documents:
- 
-* `API Developer Guide <http://docs.rackspace.com>`__: 
-  reference material *describing* API requests and sample responses
-   
-* `API Getting Started Guide <http://docs.rackspace.com>`__: 
-  tutorial material *demonstrating* simple interactions
-  with the API 
- 
-We published these API documents primarily to support readers who are 
-already experienced with RESTful APIs in other contexts and 
-are seeking details specifically about Rackspace's APIs. 
-We don't publish a beginner-level API tutorial. 
-However, REST is widely used and introductory material is
-readily available. 
-If you wish to work with our APIs and this would be your first
-experience with RESTful APIs, 
-begin with :ref:`setup_API`.
-
-
-DevOps tools
-^^^^^^^^^^^^
-If you use popular DevOps tools such as Knife, Vagrant, Ansible, and
-Salt, you may be interested in plugins (official or unofficial) for
-these automation frameworks. Sources of more information about these
-plugins include:
-
-* Knife: https://github.com/opscode/knife-rackspace
-
-* Vagrant: https://github.com/mitchellh/vagrant-rackspace
-
-* Ansible: http://docs.ansible.com/guide_rax.html
-
-* Salt: http://docs.saltstack.com/en/latest/topics/cloud/rackspace.html
+If you are responsible for administering systems that are
+used for cloud software development, 
+you may want to investigate DevOps tools 
+designed for this purpose. 
 
 Contents:
 
 .. toctree::
    :maxdepth: 2
 
+   devopstools
+   SDK
+   APIdirect
    setup_API
    cloudservers_API
    cloudnetworks_API

--- a/cloud_interfaces/API/setup_API.rst
+++ b/cloud_interfaces/API/setup_API.rst
@@ -1,8 +1,8 @@
 .. _setup_API:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Setting up to use SDKS and APIs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------
+Preparing to use SDKs and APIs
+------------------------------
 If you have a Rackspace cloud account, you can use Rackspace APIs 
 to interact with the cloud services you subscribe to. 
 

--- a/cloud_interfaces/CLI/setup_CLI.rst
+++ b/cloud_interfaces/CLI/setup_CLI.rst
@@ -1,8 +1,8 @@
 .. _setup_CLI:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~
-Setting up to use rax-cli
-~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------
+Preparing to use a CLI
+----------------------
 xxxxxxxx
 
 You must have a Rackspace account.

--- a/cloud_interfaces/GUI/index.rst
+++ b/cloud_interfaces/GUI/index.rst
@@ -19,9 +19,9 @@ first tasks:
 * `obtain your API key <http://www.rackspace.com/knowledge_center/article/view-and-reset-your-api-key>`__
   for use with 
   :ref:`CLIs <cloud_interfaces_CLI>`, 
-  :ref:`SDKs <cloud_interfaces_API-SDK>`, 
+  :ref:`SDKs <SDK>`, 
   and 
-  :ref:`APIs <cloud_interfaces_API-APIdirect>`
+  :ref:`APIs <APIdirect>`
 
 * `create additional account users <http://www.rackspace.com/knowledge_center/article/managing-role-based-access-control-rbac>`__ 
   and give them 

--- a/cloud_interfaces/GUI/setup_GUI.rst
+++ b/cloud_interfaces/GUI/setup_GUI.rst
@@ -1,8 +1,8 @@
 .. _setup_GUI:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Setting up to use the Cloud Control Panel
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Preparing to use the Cloud Control Panel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 To use the Rackspace Cloud Control Panel, you need:
 
 * a Web browser

--- a/cloud_interfaces/index.rst
+++ b/cloud_interfaces/index.rst
@@ -3,26 +3,40 @@
 ==========================
 Interacting with the cloud
 ==========================
-One of the benefits of having an open standards based cloud, designed for
-consistency and ease of use, is that there are multiple ways to interact with
+One of the benefits of having a cloud based on open standards, 
+designed for
+consistency and ease of use, 
+is that there are multiple ways to interact with
 and manage your cloud resources.
 
-Depending on your needs, you may prefer a web based control panel, software
-integration with your current applications and workflows, or shell scripting. In
-almost all cases, the functionality available is going to be similar, so it
-comes down to a personal choice or business needs.
+Depending on your needs, 
+you may prefer to interact with the cloud through 
+a web-based control panel, 
+software
+integration with your current applications and workflows, 
+or shell scripting. 
+In almost all cases, 
+the functionality available is, 
+so you can choose an interface
+based on personal preference or business needs.
 
-The Rackspace Cloud provides OpenStack-based Application Programming Interfaces
-(APIs) for all of its management functionality. These APIs are actually what
-power the Cloud Control Panel, the Command Line Interfaces, and Software
-Development Kits (as well as providing powerful raw API access). Each of these
+The Rackspace cloud provides 
+OpenStack-based Application Programming Interfaces
+(APIs) for all of its management functionality. 
+These APIs are actually what
+power the Cloud Control Panel, the Command Line Interfaces (CLIs), 
+and Software
+Development Kits (SDKs). 
+Each of these
 interfaces take the OpenStack APIs and provide the best user or developer
 experience for each situation.
+The APIs themselves 
+also provide direct programmatic access to cloud services.
 
 Contents:
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 6  
 
    GUI/index
    CLI/index

--- a/doc-inventory-referenceIDs.md
+++ b/doc-inventory-referenceIDs.md
@@ -59,6 +59,8 @@ Link to a page within the site by using its reference ID.
 
 **Inventory**
 
+APIdirect                              = /cloud_interfaces/API/APIdirect.rst
+
 assumptions                            = /cloud_guide_intro/assumptions.rst
 
 backups                                = /cloud_preprod/backups.rst
@@ -102,8 +104,6 @@ cloud-init_boot                        = /cloud_config/compute/cloud_servers_pro
 cloud_interfaces                       = /cloud_interfaces/index.rst
 
 cloud_interfaces_API                   = /cloud_interfaces/API/index.rst
-cloud_interfaces_API-APIdirect         = /cloud_interfaces/API/index.rst
-cloud_interfaces_API-SDK               = /cloud_interfaces/API/index.rst
 
 cloud_interfaces_CLI                   = /cloud_interfaces/CLI/index.rst
 
@@ -177,6 +177,8 @@ data_immutability                      = /cloud_config/compute/cloud_images_prod
 
 default_base_images                    = /cloud_config/compute/cloud_images_product_concepts/base_images/default_base_images.rst
 
+devopstools                            = /cloud_interfaces/API/devopstools.rst
+
 disk_storage                           = /cloud_config/storage/cloud_block_storage_product_concepts/disk_storage.rst
 
 diskconfig                             = /cloud_config/compute/cloud_servers_product_concepts/diskconfig.rst
@@ -228,6 +230,8 @@ personality_boot                       = /cloud_config/compute/cloud_servers_pro
 publicnet                              = /cloud_config/network/cloud_networks_product_concepts/publicnet.rst
 
 scaling                                = /cloud_preprod/scaling.rst
+
+SDK                                    = /cloud_interfaces/API/SDK.rst
 
 security                               = /cloud_preprod/security.rst
 


### PR DESCRIPTION
also, for all interfaces, re title setup.rst as "Preparing to use" rather than "Setting up to use"