### PR TITLE
split Cloud Networks topics on use cases and customer benefits

### DIFF
--- a/cloud_config/network/cloud_networks_product_concepts/cloudnetworks-benefits.rst
+++ b/cloud_config/network/cloud_networks_product_concepts/cloudnetworks-benefits.rst
@@ -1,0 +1,43 @@
+.. _cloudnetworks-benefits:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Customer benefits from Cloud Networks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These are some of the ways in which Cloud Networks can 
+be useful within your Cloud Servers configuration: 
+
+* **Isolate your servers**
+
+    You can create Cloud Servers without public or 
+    private (ServiceNet) network interfaces, 
+    making them accessible only through Cloud Networks.
+
+* **Support clustering** 
+
+    You can take advantage of full support 
+    for broadcasting and multicasting as 
+    required for some clustering technologies.
+
+* **Simplify network changes**
+
+    You can make networking changes to existing deployments 
+    without having to rebuild your cloud server.
+
+* **Automate network changes**
+
+    Via the Cloud Networks API, 
+    you can develop custom software to automatically 
+    create networks and attach or detach Cloud Servers 
+    based on workload requirements.
+
+* **Support complex topologies**
+
+    You can combine Cloud Networks with 
+    `Brocade Vyatta Routers <http://www.rackspace.com/cloud/servers/vrouter/>`__ 
+    to create complex topologies that route traffic 
+    between Cloud Networks or to external data centers over VPN.
+
+* **Scale networks as you grow** 
+
+    Up to 250 Cloud Servers can be attached to a single cloud network.
+    You can have up to 10 cloud networks per region. 

--- a/cloud_config/network/cloud_networks_product_concepts/cloudnetworks-usecases.rst
+++ b/cloud_config/network/cloud_networks_product_concepts/cloudnetworks-usecases.rst
@@ -1,0 +1,28 @@
+.. _cloudnetworks-usecases:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Typical use cases for Cloud Networks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cloud Networks is especially useful for 
+tightening security, increasing flexibility, 
+and maintaining uninterrupted availability. 
+
+**Security**
+
+  Get fully isolated, single-tenant Layer 2 networks designed to securely
+  transfer sensitive information between Cloud Servers located in the same
+  region.
+
+**Flexibility and control**
+
+  Control IP addressing (IPv4 or IPv6) and topology to create networks
+  that suit your workload. For example, 
+  you can create one network between web servers and
+  app servers, 
+  and another network between app servers and database servers.
+
+**High availability**
+
+  Because multiple Cloud Servers can share the same IP address, you can
+  use fast IP address failover to enable high availability without making
+  a separate API call.

--- a/cloud_config/network/cloud_networks_product_concepts/index.rst
+++ b/cloud_config/network/cloud_networks_product_concepts/index.rst
@@ -6,72 +6,20 @@ Understanding Cloud Networks
 Your Cloud Server configuration can include several kinds of networks,
 connected as appropriate for your needs.
 
-Typical use cases
-~~~~~~~~~~~~~~~~~
+Using Cloud Networks, you can connect 
+virtual cloud servers with other virtual cloud servers, 
+with OnMetal cloud servers, 
+and, with RackConnect, 
+with dedicated servers operating outside the cloud. 
 
-**Security**
-
-  Get fully isolated, single-tenant Layer 2 networks designed to securely
-  transfer sensitive information between Cloud Servers located in the same
-  region.
-
-**Flexibility and control**
-
-  Control IP addressing (IPv4 or IPv6) and topology to create networks
-  that suit your workload—for example, create one network between web and
-  app servers, and another between app and database servers.
-
-**High availability**
-
-  Because multiple Cloud Servers can share the same IP address, you can
-  use fast IP address failover to enable high availability without making
-  a separate API call.
-
-Customer benefits
-~~~~~~~~~~~~~~~~~
-These are some of the ways in which Cloud Networks can 
-be useful within your Cloud Servers configuration: 
-
-* **Isolate your servers**
-
-    You can create Cloud Servers without public or 
-    private (ServiceNet) network interfaces, 
-    making them accessible only through Cloud Networks.
-
-* **Support clustering** 
-
-    Includes full support for broadcasting and multicasting as 
-    required for some clustering technologies.
-
-* **Simplify network changes**
-
-    You can make networking changes to existing deployments 
-    without having to rebuild your Cloud Server.
-
-* **Automate network changes**
-
-    Via the Cloud Networks API, 
-    you can develop custom software to automatically 
-    create networks and attach or detach Cloud Servers 
-    based on workload requirements.
-
-* **Support complex topologies**
-
-    Combine with 
-    `Brocade Vyatta Routers <http://www.rackspace.com/cloud/servers/vrouter/>`__ 
-    to create complex topologies that route traffic 
-    between Cloud Networks or to external data centers over VPN.
-
-* **Scale networks as you grow** 
-
-    Up to 250 Cloud Servers can be attached to a single cloud network.
-    You can have up to 10 cloud networks per region. 
 
 Contents:
 
 .. toctree::
    :maxdepth: 2
 
+   cloudnetworks-usecases
+   cloudnetworks-benefits
    network_cloud_servers
    network_onmetal_servers
    network_rackconnect

--- a/doc-inventory-referenceIDs.md
+++ b/doc-inventory-referenceIDs.md
@@ -121,6 +121,10 @@ cloud_networks_product_actions         = /cloud_config/network/cloud_networks_pr
 
 cloud_networks_product_concepts        = /cloud_config/network/cloud_networks_product_concepts/index.rst
 
+cloudnetworks-benefits                 = /cloud_config/network/cloud_networks_product_concepts/cloudnetworks-benefits.rst
+
+cloudnetworks-usecases                 = /cloud_config/network/cloud_networks_product_concepts/cloudnetworks-usecases.rst
+
 cloud_ops                              = /cloud_ops/index.rst
 
 cloud_preprod                          = /cloud_preprod/index.rst


### PR DESCRIPTION
move these out of index.rst into separate files. 
This improves the depth of Cloud Networks content shown in the lefthand TOC