### PR TITLE
fixing up the table in the intro

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -6,54 +6,45 @@ Rackspace Cloud Guide to Core Infrastructure Services
 
 Introduction
 ------------
-This is a guide to the core infrastructure services 
+This is a guide to the core infrastructure services
 at the heart of the Rackspace cloud:
 
-+----------------------------------------------+-----------------------------------------+
-| **Cloud Servers**                            | * :ref:`cloud_servers_product_concepts` |
-|                                              | * :ref:`cloud_servers_product_actions`  |
-| .. image::                                   | * :ref:`cloudservers_GUI`               |
-|    /_images/logo-cloudservers-50x50.png      | * :ref:`cloudservers_CLI`               |
-|   :alt: Cloud Servers provides               | * :ref:`cloudservers_API`               |
-|         computing power.                     |                                         |
-|   :align: center                             |                                         |
-|                                              |                                         |
-| *Cloud Servers provides                      |                                         |
-| computing power.*                            |                                         |
-|                                              |                                         |
-+----------------------------------------------+-----------------------------------------+
- 
- 
-+----------------------------------------------+------------------------------------------+
-| **Cloud Networks**                           | * :ref:`cloud_networks_product_concepts` |
-|                                              | * :ref:`cloud_networks_product_actions`  |
-| .. image::                                   | * :ref:`cloudnetworks_GUI`               |
-|    /_images/logo-cloudnetworks-50x50.png     | * :ref:`cloudnetworks_CLI`               |
-|   :alt: Cloud Networks connects              | * :ref:`cloudnetworks_API`               |
-|         Cloud Servers.                       |                                          |
-|   :align: center                             |                                          |
-|                                              |                                          |
-| *Cloud Networks connects                     |                                          |
-| cloud servers.*                              |                                          |
-|                                              |                                          |
-+----------------------------------------------+------------------------------------------+
- 
- 
-+----------------------------------------------+----------------------------------------+
-| **Cloud Images**                             | * :ref:`cloud_images_product_concepts` |
-|                                              | * :ref:`cloud_images_product_actions`  |
-| .. image::                                   | * :ref:`cloudimages_GUI`               |
-|    /_images/logo-cloudimages-50x50.png       | * :ref:`cloudimages_CLI`               |
-|   :alt: Cloud Images standardizes            | * :ref:`cloudimages_API`               |
-|         cloud server creation.               |                                        |
-|   :align: center                             |                                        |
-|                                              |                                        |
-| *Cloud Images standardizes                   |                                        |
-| cloud server creation.*                      |                                        |
-|                                              |                                        |
-+----------------------------------------------+----------------------------------------+
- 
- 
++----------------------------------------------+-----------------------------------------------+
+| **Cloud Servers**                            | * :ref:`cloud_servers_product_concepts`       |
+|                                              | * :ref:`cloud_servers_product_actions`        |
+| .. image::                                   | * :ref:`cloudservers_GUI`                     |
+|    /_images/logo-cloudservers-50x50.png      | * :ref:`cloudservers_CLI`                     |
+|   :alt: Cloud Servers provides               | * :ref:`cloudservers_API`                     |
+|         computing power.                     |                                               |
+|   :align: center                             |                                               |
+|                                              |                                               |
+| *Cloud Servers provides                      |                                               |
+| computing power.*                            |                                               |
+|                                              |                                               |
++----------------------------------------------+-----------------------------------------------+
+| **Cloud Networks**                           | * :ref:`cloud_networks_product_concepts`      |
+|                                              | * :ref:`cloud_networks_product_actions`       |
+| .. image::                                   | * :ref:`cloudnetworks_GUI`                    |
+|    /_images/logo-cloudnetworks-50x50.png     | * :ref:`cloudnetworks_CLI`                    |
+|   :alt: Cloud Networks connects              | * :ref:`cloudnetworks_API`                    |
+|         Cloud Servers.                       |                                               |
+|   :align: center                             |                                               |
+|                                              |                                               |
+| *Cloud Networks connects                     |                                               |
+| cloud servers.*                              |                                               |
+|                                              |                                               |
++----------------------------------------------+-----------------------------------------------+
+| **Cloud Images**                             | * :ref:`cloud_images_product_concepts`        |
+|                                              | * :ref:`cloud_images_product_actions`         |
+| .. image::                                   | * :ref:`cloudimages_GUI`                      |
+|    /_images/logo-cloudimages-50x50.png       | * :ref:`cloudimages_CLI`                      |
+|   :alt: Cloud Images standardizes            | * :ref:`cloudimages_API`                      |
+|         cloud server creation.               |                                               |
+|   :align: center                             |                                               |
+|                                              |                                               |
+| *Cloud Images standardizes                   |                                               |
+| cloud server creation.*                      |                                               |
+|                                              |                                               |
 +----------------------------------------------+-----------------------------------------------+
 | **Cloud Block Storage**                      | * :ref:`cloud_block_storage_product_concepts` |
 |                                              | * :ref:`cloud_block_storage_product_actions`  |
@@ -67,15 +58,15 @@ at the heart of the Rackspace cloud:
 | cloud server storage.*                       |                                               |
 |                                              |                                               |
 +----------------------------------------------+-----------------------------------------------+
- 
- 
+
+
 .. WARNING::
    **This guide is a work in progress.**
-   You are reading an early draft; 
+   You are reading an early draft;
    be very cautious about acting on anything you read here.
 
-We want to hear what you think about this guide. 
-If you have a suggestion regarding the content, 
+We want to hear what you think about this guide.
+If you have a suggestion regarding the content,
 please :ref:`contactus`.
 
 


### PR DESCRIPTION
The ReStructuredText on the main page was rendering as several separate tables instead of one, combined table. This PR corrects that issue.