### PR TITLE
changed Cloud Server to Cloud Servers

### DIFF
--- a/cloud-intro/core-infrastructure.rst
+++ b/cloud-intro/core-infrastructure.rst
@@ -19,7 +19,7 @@ of the same functions as hardware devices in our data centers:
   transferred from one cloud server to another.
 
 * Cloud Images preserves a consistent starting point for new Cloud
-  Server instances.
+  Servers instances.
 
 * Additional services enable specific activities such as user
   authentication, load balancing, and event monitoring.


### PR DESCRIPTION
fixed name of Cloud Servers product in 1.2.1 Backspace cloud core infrastructure at a glance section