### PR TITLE
improve structure of boot section

### DIFF
--- a/cloud-config/compute/cloud-servers-product-concepts/boot/cloud-init-boot.rst
+++ b/cloud-config/compute/cloud-servers-product-concepts/boot/cloud-init-boot.rst
@@ -1,4 +1,4 @@
-.. cloud-init-boot:
+.. _cloud-init-boot:
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Controlling boot behavior with cloud-init

--- a/cloud-config/compute/cloud-servers-product-concepts/boot/drive-boot.rst
+++ b/cloud-config/compute/cloud-servers-product-concepts/boot/drive-boot.rst
@@ -1,4 +1,4 @@
-.. drive-boot:
+.. _drive-boot:
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Controlling boot behavior with a config drive

--- a/cloud-config/compute/cloud-servers-product-concepts/boot/index.rst
+++ b/cloud-config/compute/cloud-servers-product-concepts/boot/index.rst
@@ -5,13 +5,32 @@ Controlling Cloud Server initiation
 -----------------------------------
 You can configure your cloud server so that, 
 when it is started or restarted, it 
-initiates operation in any of several ways.
+initiates operation in any of several ways:
 
+* Boot from 
+  :ref:`drive <drive-boot>` 
+  if you want to 
+  boot from the 
+  read-only drive configured with 
+  your server.
+  
+* Boot from 
+  :ref:`personality <personality-boot>` 
+  if you want to 
+  inject your own files 
+  into the boot process.
+  
+  
+* Boot from 
+  :ref:`cloud-init <cloud-init-boot>` 
+  if you want to
+  customize your boot with a 
+  cloud-init config file.
 
 
 .. toctree:: :hidden:
    :maxdepth: 2
 
-   personality-boot
    drive-boot
+   personality-boot
    cloud-init-boot

--- a/cloud-config/compute/cloud-servers-product-concepts/boot/personality-boot.rst
+++ b/cloud-config/compute/cloud-servers-product-concepts/boot/personality-boot.rst
@@ -1,4 +1,4 @@
-.. personality-boot:
+.. _personality-boot:
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Controlling boot behavior with personality


### PR DESCRIPTION
hiding section toctrees on index.rst pages made this page end uselessly, hinting that several options exist but never pointing to them. now it points to them again.