### PR TITLE
minimize references to Knowledge Center as a separate collection

### DIFF
--- a/cloud-config/compute/cloud-images-product-concepts/scheduled-images.rst
+++ b/cloud-config/compute/cloud-images-product-concepts/scheduled-images.rst
@@ -8,7 +8,6 @@ scheduled images on any servers for which the service is appropriate.
 The scheduled images service will automatically create a daily or weekly
 image of the server. Remember that a virtual machine image is not really
 a backup of a server, so whether scheduled images are an appropriate
-solution for you depends entirely on your use case. See the `Scheduled
-Images
-FAQ <http://www.rackspace.com/knowledge_center/article/scheduled-images-faq>`__
-in the Rackspace Knowledge Center for details.
+solution for you depends entirely on your use case. 
+For details, see the 
+`Scheduled Images FAQ <http://www.rackspace.com/knowledge_center/article/scheduled-images-faq>`__.

--- a/cloud-config/compute/cloud-servers-product-concepts/server-events.rst
+++ b/cloud-config/compute/cloud-servers-product-concepts/server-events.rst
@@ -48,8 +48,8 @@ You can interact with Cloud Monitoring and Auto Scale using the same
 methods you use to interact with Cloud Servers:
 
 * The `Cloud Control Panel <https://mycloud.rackspace.com/>`__, as
-  explained in the `Knowledge
-  Center <http://www.rackspace.com/knowledge_center/>`__
+  explained in its 
+  `technical documentation <http://www.rackspace.com/knowledge_center/>`__
 
 * The raxmon command-line interface (CLI)
 

--- a/cloud-config/storage/cloud-block-storage-product-concepts/index.rst
+++ b/cloud-config/storage/cloud-block-storage-product-concepts/index.rst
@@ -34,7 +34,7 @@ staging of common server images in CBS.
    For instructions on using CBS boot-from-volume, see
    `Boot a server from a Cloud Block Storage volume <http://www.rackspace.com/knowledge_center/article/boot-a-server-from-a-cloud-block-storage-volume>`__.
 
-The Rackspace Knowledge Center provides many more details about Cloud
+The Rackspace technical documentation provides many more details about Cloud
 Block Storage. Begin exploring
 at 
 `Cloud Block Storage support <http://www.rackspace.com/knowledge_center/product-page/cloud-block-storage>`__.

--- a/cloud-interfaces/api/cloudservers-api.rst
+++ b/cloud-interfaces/api/cloudservers-api.rst
@@ -79,7 +79,7 @@ available within the broader Rackspace portfolio include:
   `Rackspace Cloud Servers powered by OpenStack <http://www.rackspace.com/cloud/servers>`__
 * `Rackspace Community <https://community.rackspace.com/>`__
 * `Rackspace Marketplace <https://marketplace.rackspace.com/listing?p=1&default=true&q#!/list/page/1/>`__
-* `Rackspace Knowledge Center <http://www.rackspace.com/knowledge_center/>`__
+* `Rackspace technical documentation <http://www.rackspace.com/knowledge_center/>`__
 
 .. _cloudservers-api-demonstration:
 

--- a/cloud-interfaces/cli/nova.rst
+++ b/cloud-interfaces/cli/nova.rst
@@ -45,7 +45,7 @@ on most popular operating systems:
 
 * In the Cloud Servers API documentation at 
   `Install the nova Client with the Cloud Networks Extension <http://docs.rackspace.com/servers/api/v2/cs-gettingstarted/content/section_gs_install_nova.html>`__
-* In the Knowledge Center at 
+* In 
   `Using python-novaclient with the Rackspace Cloud <http://www.rackspace.com/knowledge_center/article/using-python-novaclient-with-the-rackspace-cloud>`__
 
 After you have novaclient installed, you will need to set up your

--- a/cloud-interfaces/gui/index.rst
+++ b/cloud-interfaces/gui/index.rst
@@ -31,9 +31,9 @@ first tasks:
   .. note::
      Users who do not have permission to use a feature 
      do not see that feature in the Cloud Control Panel. 
-     Cloud Control Panel screenshots in the
-     `Knowledge Center <http://www.rackspace.com/knowledge_center/>`__ 
-     and elsewhere may show features that are not 
+     Cloud Control Panel screenshots in 
+     `technical documentation <http://www.rackspace.com/knowledge_center/>`__ 
+     may show features that are not 
      available to some users.
 
 * View and change resource limits

--- a/cloud-intro/cloud-tour/index.rst
+++ b/cloud-intro/cloud-tour/index.rst
@@ -51,8 +51,8 @@ mention them when they are relevant.
 
 In other Rackspace resources such as the 
 `Cloud Control Panel <https://mycloud.rackspace.com/>`__
-and the 
-`Knowledge Center <http://www.rackspace.com/knowledge_center/>`__,
+and  
+`technical documentation <http://www.rackspace.com/knowledge_center/>`__,
 you should notice that Rackspace cloud products
 are grouped so that closely-related products are likely to be discussed together. 
 We follow that convention here, introducing several categories of cloud products 

--- a/cloud-intro/customer-stories.rst
+++ b/cloud-intro/customer-stories.rst
@@ -12,7 +12,7 @@ meet some of the same challenges you are facing, start at
 Other good places to find
 customer stories include:
 
-* `Case studies and white papers in the Knowledge Center <http://www.rackspace.com/knowledge_center/case-studies-white-papers>`__
+* `Case studies and white papers in technical documentation <http://www.rackspace.com/knowledge_center/case-studies-white-papers>`__
 
 * `Postings in the "Partner & Customer Updates" channel of the Rackspace blog <http://www.rackspace.com/blog/channels/partner-and-customer-updates/>`__
 


### PR DESCRIPTION
Where a reference is formed like "see article at URL in the Knowledge Center", drop mention of the Knowledge Center. 