### PR TITLE
undo experiment with adding link to intro page

### DIFF
--- a/_toc.rst
+++ b/_toc.rst
@@ -2,7 +2,6 @@
    :includehidden:
    :maxdepth: 99
    
-   index
    cloud-guide-intro/index
    cloud-intro/index
    cloud-interfaces/index


### PR DESCRIPTION
doesn't help: adds a dead link to /user-guides/ instead of /user-guides/infrastructure/