### PR TITLE
incorporating external link library

### DIFF
--- a/cloud-guide-intro/contactus.rst
+++ b/cloud-guide-intro/contactus.rst
@@ -3,27 +3,26 @@
 ----------
 Contact us
 ----------
-We want to hear what you think about this guide. 
-Here are some good ways to share your 
+We want to hear what you think about this guide.
+Here are some good ways to share your
 suggestions, questions, and comments:
 
-* Check the 
-  `list of GitHub issues <https://github.com/rackerlabs/docs-core-infra-user-guide/issues>`__. 
-  If you see something similar to what you're thinking about, 
-  open that issue and add a comment. 
-  Otherwise, create a new issue explaining what concerns you 
-  about this guide and, 
-  if you have a solution in mind, 
-  telling us what you propose we could do about it. 
-  
-  To learn more about GitHub issues, read GitHub's 
+* Check the
+  :git-repo:`list of GitHub issues <issues>`.
+  If you see something similar to what you're thinking about,
+  open that issue and add a comment.
+  Otherwise, create a new issue explaining what concerns you
+  about this guide and,
+  if you have a solution in mind,
+  telling us what you propose we could do about it.
+
+  To learn more about GitHub issues, read GitHub's
   `Mastering Issues <https://guides.github.com/features/issues/>`__.
-  
-* Send email to the guide's maintainers at 
-  userguides@rackspace.com. We'll answer as promptly as we can. 
-  
-.. NOTE::  
-   If you are seeking emergency help from Rackspace, 
-   contact Rackspace Support using one of the methods suggested at 
+
+* Send email to the guide's maintainers at
+  userguides@rackspace.com. We'll answer as promptly as we can.
+
+.. NOTE::
+   If you are seeking emergency help from Rackspace,
+   contact Rackspace Support using one of the methods suggested at
    :ref:`support`.
-  

--- a/cloud-guide-intro/document-history.rst
+++ b/cloud-guide-intro/document-history.rst
@@ -3,40 +3,40 @@
 ================
 Document history
 ================
-This version of the guide 
-replaces and obsoletes 
+This version of the guide
+replaces and obsoletes
 all previous versions.
 
-The guide is continuously improved. 
-Our documentation source repository is open for review; 
-to learn about everything that has changed recently, begin 
-by 
-`taking the repository's pulse <https://github.com/rackerlabs/docs-core-infra-user-guide/pulse>`__.  
- 
-Highlights of the most recent changes are described 
+The guide is continuously improved.
+Our documentation source repository is open for review;
+to learn about everything that has changed recently, begin
+by
+:git-repo:`taking the repository's pulse <pulse>`. 
+
+Highlights of the most recent changes are described
 in the table below:
 
 +------------------+-----------------------------------------------------------------------------------------+
 | Revision Date    | Summary of Changes                                                                      |
 +==================+=========================================================================================+
-| June 25, 2015    | * Updated list of stack templates at :ref:`stack`.                                      | 
-+------------------+-----------------------------------------------------------------------------------------+ 
-| June 18, 2015    | * First publication at `developer.rackspace.com <https://developer.rackspace.com/>`__.  | 
-+------------------+-----------------------------------------------------------------------------------------+ 
-| June 1, 2015     | * First draft with complete content.                                                    | 
+| June 25, 2015    | * Updated list of stack templates at :ref:`stack`.                                      |
 +------------------+-----------------------------------------------------------------------------------------+
-| May 22, 2014     | * Begin document development.                                                           | 
+| June 18, 2015    | * First publication at `developer.rackspace.com <https://developer.rackspace.com/>`__.  |
++------------------+-----------------------------------------------------------------------------------------+
+| June 1, 2015     | * First draft with complete content.                                                    |
++------------------+-----------------------------------------------------------------------------------------+
+| May 22, 2014     | * Begin document development.                                                           |
 +------------------+-----------------------------------------------------------------------------------------+
 
-.. Estimated publication date; 
+.. Estimated publication date;
    adjust when finalized.
 .. Add new history to the top of the table.
-.. This is the format of 
+.. This is the format of
    "Document change history"
-   sections at docs.rackspace.com, 
+   sections at docs.rackspace.com,
    such as at
    http://docs.rackspace.com/cdns/api/v1.0/
    cdns-devguide/content/
    Document_Change_History-d1e166.html.
-   If that pattern changes, change here 
-   for consistency. 
+   If that pattern changes, change here
+   for consistency.

--- a/cloud-interfaces/api/cloudblockstorage-api.rst
+++ b/cloud-interfaces/api/cloudblockstorage-api.rst
@@ -4,10 +4,10 @@
 Cloud Block Storage and SDKs and APIs
 -------------------------------------
 When you begin writing your own software
-to interact with Cloud Block Storage, 
-you may benefit from investing some time to learn about 
+to interact with Cloud Block Storage,
+you may benefit from investing some time to learn about
 how Cloud Block Storage works
-in the Cloud Control Panel 
+in the Cloud Control Panel
 and how SDKs and APIs are documented at Rackspace.
 
 .. _cloudblockstorage-api-investigation:
@@ -15,91 +15,91 @@ and how SDKs and APIs are documented at Rackspace.
 +++++++++++++++++++++++++++++++++++++
 Cloud Block Storage API investigation
 +++++++++++++++++++++++++++++++++++++
-Using an API, 
-you can write software to automate functions that could otherwise 
-be performed manually by a person logged into the Cloud Control Panel. 
-You can accelerate your understanding of how the API works 
-by using the Cloud Control Panel to demonstrate the manual process 
-before you begin to automate it; 
-to interact with the Cloud Block Storage service, 
-the Cloud Control Panel sends requests via the same API 
-that you interact with when you write your own software. 
+Using an API,
+you can write software to automate functions that could otherwise
+be performed manually by a person logged into the Cloud Control Panel.
+You can accelerate your understanding of how the API works
+by using the Cloud Control Panel to demonstrate the manual process
+before you begin to automate it;
+to interact with the Cloud Block Storage service,
+the Cloud Control Panel sends requests via the same API
+that you interact with when you write your own software.
 
-Sometimes, 
-especially for new features that are not yet available 
-in the Cloud Control Panel, 
-you can write software to perform functions 
-via the API 
-that could not be performed in any other way; 
-product announcements for Limited Availability 
-and Early Access releases point out this limitation when it applies. 
-In that case, 
-experimenting in the Cloud Control Panel can show you 
-only part of the process of working with a new feature; 
-other details are described in the 
-`API documentation <http://docs.rackspace.com>`__. 
+Sometimes,
+especially for new features that are not yet available
+in the Cloud Control Panel,
+you can write software to perform functions
+via the API
+that could not be performed in any other way;
+product announcements for Limited Availability
+and Early Access releases point out this limitation when it applies.
+In that case,
+experimenting in the Cloud Control Panel can show you
+only part of the process of working with a new feature;
+other details are described in the
+:rax-docs:`API documentation <>`.
 
-Just as you can use the Cloud Control Panel 
-to help you understand a manual process that you intend to automate, 
-you can use the API documentation to help you understand 
-how to use a Software Development Kit (SDK) 
-in your favorite programming language. 
+Just as you can use the Cloud Control Panel
+to help you understand a manual process that you intend to automate,
+you can use the API documentation to help you understand
+how to use a Software Development Kit (SDK)
+in your favorite programming language.
 
-* The API documentation describes 
-  *what* you can ask the API to do. 
-  
-* The SDK documentation demonstrates 
-  *how* to ask the API to do something. 
+* The API documentation describes
+  *what* you can ask the API to do.
 
-Awareness of both API and SDK capabilities 
-can help you to plan the easiest way to develop your software. 
+* The SDK documentation demonstrates
+  *how* to ask the API to do something.
+
+Awareness of both API and SDK capabilities
+can help you to plan the easiest way to develop your software.
 
 .. _cloudblockstorage-api-demonstration:
 
 +++++++++++++++++++++++++++++++++++++
 Cloud Block Storage API demonstration
 +++++++++++++++++++++++++++++++++++++
-Using the process suggested at 
-:ref:`cloudblockstorage-api-investigation`, 
-here is an example of how you can plan 
-and then write your own software to perform one simple task: 
-list all your Cloud Block Storage volumes. 
+Using the process suggested at
+:ref:`cloudblockstorage-api-investigation`,
+here is an example of how you can plan
+and then write your own software to perform one simple task:
+list all your Cloud Block Storage volumes.
 
-Learn about Cloud Block Storage in the Cloud Control Panel  
+Learn about Cloud Block Storage in the Cloud Control Panel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-When you login to the 
-`Cloud Control Panel <https://mycloud.rackspace.com/>`__, 
+When you login to the
+`Cloud Control Panel <https://mycloud.rackspace.com/>`__,
 your session begins with information about your Cloud Servers.
-To see your Cloud Block Storage information, click **Storage** 
-and then click **Block Storage Volumes**. 
+To see your Cloud Block Storage information, click **Storage**
+and then click **Block Storage Volumes**.
 
 .. figure:: /_images/StorageBlockStorageVolumes.png
    :scale: 80%
-   :alt: To move from Cloud Servers to 
-         Cloud Block Storage details, 
+   :alt: To move from Cloud Servers to
+         Cloud Block Storage details,
          click Storage and then click Block Storage Volumes.
 
-   *To move from Cloud Servers to 
-   Cloud Block Storage details, 
+   *To move from Cloud Servers to
+   Cloud Block Storage details,
    click "Storage" and then click "Block Storage Volumes".*
 
-By default, the list is focused on your account's home region, 
-showing all volumes in that region; 
-you can select a different region and you can search for a 
+By default, the list is focused on your account's home region,
+showing all volumes in that region;
+you can select a different region and you can search for a
 specific volume.
 
 .. figure:: /_images/CloudBlockStorage0volumes.png
    :scale: 80%
-   :alt: If you have no Cloud Block Storage volumes, 
-         the Cloud Control Panel shows you how to 
+   :alt: If you have no Cloud Block Storage volumes,
+         the Cloud Control Panel shows you how to
          create one.
-         
-   *If you have no Cloud Block Storage volumes, 
-   the Cloud Control Panel shows you how to 
+
+   *If you have no Cloud Block Storage volumes,
+   the Cloud Control Panel shows you how to
    create one.*
-         
-If your list of volumes is not empty, then for each volume 
-you can see: 
+
+If your list of volumes is not empty, then for each volume
+you can see:
 
 * Its ID
 * The name of the server to which it is attached
@@ -111,110 +111,110 @@ you can see:
    :scale: 80%
    :alt: The Cloud Control Panel lists all of your
          Cloud Block Storage volumes.
-         
+
    *The Cloud Control Panel lists all of your
    Cloud Block Storage volumes.*
-         
+
 .. include:: note-chrome-devtools.rst
 
 Learn about Cloud Block Storage in API documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In the 
-`API cross-reference <http://api.rackspace.com/>`__, 
-you can see all available API operations for all cloud services. 
-The operations are grouped according to the service they interact 
-with (for example, Cloud Block Storage or Cloud Files) 
-and the scope they act upon (for example, volumes or snapshots). 
+In the
+`API cross-reference <http://api.rackspace.com/>`__,
+you can see all available API operations for all cloud services.
+The operations are grouped according to the service they interact
+with (for example, Cloud Block Storage or Cloud Files)
+and the scope they act upon (for example, volumes or snapshots).
 
-You can see all Cloud Block Storage operations in the 
-`API cross-reference <http://api.rackspace.com/api-ref-blockstorage.html>`__; 
-in the group of 
-`operations that act upon volumes <http://api.rackspace.com/api-ref-blockstorage.html#volumes>`__, 
+You can see all Cloud Block Storage operations in the
+:rax-api:`API cross-reference <api-ref-blockstorage.html>`;
+in the group of
+:rax-api:`operations that act upon volumes <api-ref-blockstorage.html#volumes>`,
 you can see that:
 
-* Sending a ``POST`` to the ``v1/{tenant_id}/volumes`` 
+* Sending a ``POST`` to the ``v1/{tenant_id}/volumes``
   URI requests creation of a new server
 
-* Sending a ``GET`` to the same URI  
+* Sending a ``GET`` to the same URI
   requests a basic list of information about volumes
 
-* Sending a ``GET`` to the same URI and appending ``/detail`` 
+* Sending a ``GET`` to the same URI and appending ``/detail``
   requests an expanded list of information about volumes
 
 .. figure:: /_images/CloudBlockStorageListVolumesGET.png
    :scale: 80%
    :alt: api.rackspace.com lists all API operations.
-   
+
    *The API cross-reference lists all API operations.*
 
-On the first ``GET`` line, click **detail** to see 
-more about how the API handles this request.  
-The request parameters and sample response shown here can 
-help you formulate a basic *List volumes* request to the API 
-and understand the API's 
-response. 
-  
-In the sample response, 
-``id``, ``display_name``, ``size``, and ``volume_type`` 
-correspond to the information available on the Cloud Control Panel. 
- 
-In the 
-`Getting Started Guide for the Cloud Block Storage API <http://docs.rackspace.com/cbs/api/v1.0/cbs-getting-started/>`__, 
-you can see an example of  
-`obtaining a list of Cloud Block Storage volumes by using the cURL command-line interface (CLI) 
-<http://docs.rackspace.com/cbs/api/v1.0/cbs-getting-started/content/Listing_volumes_d1e060.html>`__. 
+On the first ``GET`` line, click **detail** to see
+more about how the API handles this request.
+The request parameters and sample response shown here can
+help you formulate a basic *List volumes* request to the API
+and understand the API's
+response.
+
+In the sample response,
+``id``, ``display_name``, ``size``, and ``volume_type``
+correspond to the information available on the Cloud Control Panel.
+
+In the
+:rax-docs:`Getting Started Guide for the Cloud Block Storage API <cbs/api/v1.0/cbs-getting-started>`,
+you can see an example of
+:rax-docs:`obtaining a list of Cloud Block Storage volumes by using the cURL command-line interface (CLI)
+<cbs/api/v1.0/cbs-getting-started/content/Listing_volumes_d1e060.html>`.
 
 Learn about Cloud Block Storage in SDK QuickStart
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In the 
-`SDK QuickStart for Cloud Block Storage <https://developer.rackspace.com/docs/cloud-block-storage/getting-started/>`__,
-you can see some of the same steps that are documented in 
-the API's Getting Started Guide. 
-For example, both the API-focused and SDK-focused documents 
-show how to authenticate with your API key before issuing any requests 
-to the Cloud Block Storage API. 
- 
-The SDK QuickStart adds examples in several popular programming 
-languages, 
-demonstrating how to use each language to 
-code some commonly-used requests to the 
-Cloud Block Storage API. 
+In the
+:rax-dev:`SDK QuickStart for Cloud Block Storage <docs/cloud-block-storage/getting-started>`,
+you can see some of the same steps that are documented in
+the API's Getting Started Guide.
+For example, both the API-focused and SDK-focused documents
+show how to authenticate with your API key before issuing any requests
+to the Cloud Block Storage API.
 
-To see examples in a specific language, 
-click that language's name in the list across the top of the page. 
-For example, to see Cloud Block Storage code samples coded in PHP, 
-go to the 
-`SDK QuickStart for Cloud Block Storage <https://developer.rackspace.com/docs/cloud-block-storage/getting-started/>`__ 
-and click *PHP*. 
+The SDK QuickStart adds examples in several popular programming
+languages,
+demonstrating how to use each language to
+code some commonly-used requests to the
+Cloud Block Storage API.
+
+To see examples in a specific language,
+click that language's name in the list across the top of the page.
+For example, to see Cloud Block Storage code samples coded in PHP,
+go to the
+:rax-dev:`SDK QuickStart for Cloud Block Storage <docs/cloud-block-storage/getting-started>`
+and click *PHP*.
 
 .. figure:: /_images/CloudBlockStorageSDKPHP.png
    :scale: 80%
-   :alt: PHP is one of several languages for which we 
+   :alt: PHP is one of several languages for which we
          publish an SDK QuickStart.
-         
-   *PHP is one of several languages for which we 
+
+   *PHP is one of several languages for which we
    publish an SDK QuickStart.*
 
 Use SDK to help you write and run code to interact with Cloud Block Storage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The SDK QuickStart demonstrates a few basic requests; 
-for more detailed guidance, 
-perhaps enough to walk you through exactly the steps required 
-to develop your software, examine the SDK itself. 
+The SDK QuickStart demonstrates a few basic requests;
+for more detailed guidance,
+perhaps enough to walk you through exactly the steps required
+to develop your software, examine the SDK itself.
 
-To find the full SDK for your programming language, start at 
-`SDKs & Tools in the Developer Center <https://developer.rackspace.com/sdks/>`__ 
-and find the language. 
-Then follow the steps appropriate to that language. 
+To find the full SDK for your programming language, start at
+:rax-dev:`SDKs & Tools in the Developer Center <sdks>`
+and find the language.
+Then follow the steps appropriate to that language.
 
-For example, if you code in PHP, 
+For example, if you code in PHP,
 
-* Follow the installation instructions to give yourself 
-  a local copy of the php-opencloud SDK. 
-* In the 
+* Follow the installation instructions to give yourself
+  a local copy of the php-opencloud SDK.
+* In the
   `documentation repository for php-opencloud <http://docs.php-opencloud.com/>`__,
-  read about the *Volumes v1* service, 
-  applicable to both Rackspace and OpenStack configurations. 
-  In that document,  
-  you can go directly to an 
-  `example of listing Cloud Block Storage volumes <http://docs.php-opencloud.com/en/latest/services/volume/volumes.html#list-volumes>`__. 
+  read about the *Volumes v1* service,
+  applicable to both Rackspace and OpenStack configurations.
+  In that document,
+  you can go directly to an
+  `example of listing Cloud Block Storage volumes <http://docs.php-opencloud.com/en/latest/services/volume/volumes.html#list-volumes>`__.

--- a/cloud-interfaces/api/cloudimages-api.rst
+++ b/cloud-interfaces/api/cloudimages-api.rst
@@ -4,10 +4,10 @@
 Cloud Images and SDKs and APIs
 ------------------------------
 When you begin writing your own software
-to interact with Cloud Images, 
-you may benefit from investing some time to learn about 
+to interact with Cloud Images,
+you may benefit from investing some time to learn about
 how Cloud Images works
-in the Cloud Control Panel 
+in the Cloud Control Panel
 and how SDKs and APIs are documented at Rackspace.
 
 .. _cloudimages-api-investigation:
@@ -15,43 +15,43 @@ and how SDKs and APIs are documented at Rackspace.
 ++++++++++++++++++++++++++++++
 Cloud Images API investigation
 ++++++++++++++++++++++++++++++
-Using an API, 
-you can write software to automate functions that could otherwise 
-be performed manually by a person logged into the Cloud Control Panel. 
-You can accelerate your understanding of how the API works 
-by using the Cloud Control Panel to demonstrate the manual process 
-before you begin to automate it; 
-to interact with the Cloud Images service, 
-the Cloud Control Panel sends requests via the same API 
+Using an API,
+you can write software to automate functions that could otherwise
+be performed manually by a person logged into the Cloud Control Panel.
+You can accelerate your understanding of how the API works
+by using the Cloud Control Panel to demonstrate the manual process
+before you begin to automate it;
+to interact with the Cloud Images service,
+the Cloud Control Panel sends requests via the same API
 that you interact with when you write your own software.
 
-Sometimes, 
-especially for new features that are not yet available 
-in the Cloud Control Panel, 
-you can write software to perform functions 
-via the API 
-that could not be performed in any other way; 
-product announcements for Limited Availability 
-and Early Access releases point out this limitation when it applies. 
-In that case, 
-experimenting in the Cloud Control Panel can show you 
-only part of the process of working with a new feature; 
-other details are described in the 
-`API documentation <http://docs.rackspace.com>`__. 
+Sometimes,
+especially for new features that are not yet available
+in the Cloud Control Panel,
+you can write software to perform functions
+via the API
+that could not be performed in any other way;
+product announcements for Limited Availability
+and Early Access releases point out this limitation when it applies.
+In that case,
+experimenting in the Cloud Control Panel can show you
+only part of the process of working with a new feature;
+other details are described in the
+:rax-api:`API documentation <>`.
 
-Just as you can use the Cloud Control Panel 
-to help you understand a manual process that you intend to automate, 
-you can use the API documentation to help you understand 
-how to use a Software Development Kit (SDK) 
-in your favorite programming language. 
+Just as you can use the Cloud Control Panel
+to help you understand a manual process that you intend to automate,
+you can use the API documentation to help you understand
+how to use a Software Development Kit (SDK)
+in your favorite programming language.
 
-* The API documentation describes 
-  *what* you can ask the API to do. 
-  
-* The SDK documentation demonstrates 
-  *how* to ask the API to do something. 
-  
-Awareness of both API and SDK capabilities 
+* The API documentation describes
+  *what* you can ask the API to do.
+
+* The SDK documentation demonstrates
+  *how* to ask the API to do something.
+
+Awareness of both API and SDK capabilities
 can help you to plan the easiest way to develop your software.
 
 .. _cloudimages-api-demonstration:
@@ -59,37 +59,37 @@ can help you to plan the easiest way to develop your software.
 ++++++++++++++++++++++++++++++
 Cloud Images API demonstration
 ++++++++++++++++++++++++++++++
-Using the process suggested at 
-:ref:`cloudimages-api-investigation`, 
-here is an example of how you can plan 
-and then write your own software to perform one simple task: 
-list all your cloud images. 
+Using the process suggested at
+:ref:`cloudimages-api-investigation`,
+here is an example of how you can plan
+and then write your own software to perform one simple task:
+list all your cloud images.
 
-Learn about Cloud Images in the Cloud Control Panel  
+Learn about Cloud Images in the Cloud Control Panel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-When you login to the 
-`Cloud Control Panel <https://mycloud.rackspace.com/>`__, 
+When you login to the
+`Cloud Control Panel <https://mycloud.rackspace.com/>`__,
 your session begins with information about your servers.
-To see your Cloud Images information, click **Servers** 
-and then click **Saved Images**. 
+To see your Cloud Images information, click **Servers**
+and then click **Saved Images**.
 
 .. figure:: /_images/ServersSavedImages.png
    :scale: 80%
-   :alt: To move from Cloud Servers to 
-         Cloud Images details, 
+   :alt: To move from Cloud Servers to
+         Cloud Images details,
          click Servers and then click Saved Images.
-   
-   *To move from Cloud Servers to 
-   Cloud Images details, 
+
+   *To move from Cloud Servers to
+   Cloud Images details,
    click "Servers" and then click "Saved Images".*
-     
-By default, the list is focused on your account's home region, 
-showing all images in that region; 
-you can select a different region and you can search for a 
+
+By default, the list is focused on your account's home region,
+showing all images in that region;
+you can select a different region and you can search for a
 specific image.
 
-If your list of images is not empty, then for each image 
-you can see 
+If your list of images is not empty, then for each image
+you can see
 
 * Its name
 * The server from which it was created
@@ -99,109 +99,109 @@ you can see
 .. figure:: /_images/CloudImagesListAll.png
    :alt: The Cloud Control Panel lists all of your
          Cloud Networks networks.
-         
+
    *The Cloud Control Panel lists all of your
    Cloud Networks networks.*
-         
+
 .. include:: note-chrome-devtools.rst
 
 Learn about Cloud Images in API documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In the 
-`API cross-reference <http://api.rackspace.com/>`__,
-you can see all available API operations for all cloud services. 
-The operations are grouped according to the service they interact 
-with (for example, Cloud Images or Cloud Files) 
-and the scope they act upon (for example, images or image schemas). 
+In the
+:rax-api:`API cross-reference <>`,
+you can see all available API operations for all cloud services.
+The operations are grouped according to the service they interact
+with (for example, Cloud Images or Cloud Files)
+and the scope they act upon (for example, images or image schemas).
 
-You can see all Cloud Images operations in the 
-`API cross-reference <http://api.rackspace.com/api-ref-images.html>`__; 
-in the group of 
-`operations that act upon images <http://api.rackspace.com/api-ref-images.html#images>`__, 
+You can see all Cloud Images operations in the
+:rax-api:`API cross-reference <api-ref-images.html>`;
+in the group of
+:rax-api:`operations that act upon images <api-ref-images.html#images>`,
 you can see that:
-   
-* Sending a ``GET`` to the ``images``  
+
+* Sending a ``GET`` to the ``images``
   URI requests a basic list of information about public images
 
-* Sending a ``GET`` to the same URI and appending an image ID 
+* Sending a ``GET`` to the same URI and appending an image ID
   requests an expanded list of information about a single image
 
 .. figure:: /_images/CloudImagesListImagesGET.png
    :scale: 80%
    :alt: api.rackspace.com lists all API operations.
-   
+
    *The API cross-reference lists all API operations.*
 
-On the first ``GET`` line, click **detail** to see 
-more about how the API handles this request.  
-The request parameters and sample response shown here can 
-help you formulate a basic *List images* request to the API 
-and understand the API's 
+On the first ``GET`` line, click **detail** to see
+more about how the API handles this request.
+The request parameters and sample response shown here can
+help you formulate a basic *List images* request to the API
+and understand the API's
 response.
 
-In the sample response, 
-``name``, ``created_at``, ``size``, and ``id`` 
+In the sample response,
+``name``, ``created_at``, ``size``, and ``id``
 correspond to the information available on the Cloud Control Panel.
 
-In the 
-`Getting Started Guide for the Cloud Images API <http://docs.rackspace.com/images/api/v2/ci-gettingstarted/>`__, 
-you can see an example of  
-`obtaining a list of images by using the cURL command-line interface (CLI) 
-<http://docs.rackspace.com/images/api/v2/ci-gettingstarted/content/list-images.html>`__. 
+In the
+:rax-docs:`Getting Started Guide for the Cloud Images API <images/api/v2/ci-gettingstarted>`,
+you can see an example of
+:rax-docs:`obtaining a list of images by using the cURL command-line interface (CLI)
+<images/api/v2/ci-gettingstarted/content/list-images.html>`.
 
 Learn about Cloud Images in SDK QuickStart
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-In the 
-`SDK QuickStart for Cloud Images <https://developer.rackspace.com/docs/cloud-images/getting-started/>`__,
-you can see some of the same steps that are documented in 
-the API's Getting Started Guide. 
-For example, both the API-focused and SDK-focused documents 
-show how to authenticate with your API key before issuing any requests 
+In the
+:rax-dev:`SDK QuickStart for Cloud Images <docs/cloud-images/getting-started>`,
+you can see some of the same steps that are documented in
+the API's Getting Started Guide.
+For example, both the API-focused and SDK-focused documents
+show how to authenticate with your API key before issuing any requests
 to the Cloud Images API.
 
-The SDK QuickStart adds examples in several popular programming 
-languages, 
-demonstrating how to use each language to 
-code some commonly-used requests to the 
+The SDK QuickStart adds examples in several popular programming
+languages,
+demonstrating how to use each language to
+code some commonly-used requests to the
 Cloud Images API.
 
-To see examples in a specific language, 
-click that language's name in the list across the top of the page. 
-For example, to see Cloud Images code samples coded in python, 
-go to the 
-`SDK QuickStart for Cloud Images <https://developer.rackspace.com/docs/cloud-images/getting-started/>`__ 
+To see examples in a specific language,
+click that language's name in the list across the top of the page.
+For example, to see Cloud Images code samples coded in python,
+go to the
+:rax-dev:`SDK QuickStart for Cloud Images <docs/cloud-images/getting-started>`
 and click **PYTHON**.
 
 .. figure:: /_images/CloudImagesSDKpython.png
    :scale: 80%
-   :alt: Python is one of several languages for which we 
+   :alt: Python is one of several languages for which we
          publish an SDK QuickStart.
-         
-   *Python is one of several languages for which we 
+
+   *Python is one of several languages for which we
    publish an SDK QuickStart.*
 
 Use SDK to help you write and run code to interact with Cloud Images
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The SDK QuickStart demonstrates a few basic requests; 
-for more detailed guidance, 
-perhaps enough to walk you through exactly the steps required 
-to develop your software, examine the SDK itself. 
+The SDK QuickStart demonstrates a few basic requests;
+for more detailed guidance,
+perhaps enough to walk you through exactly the steps required
+to develop your software, examine the SDK itself.
 
-To find the full SDK for your programming language, start at 
-`SDKs & Tools in the Developer Center <https://developer.rackspace.com/sdks/>`__ 
-and find the language. 
+To find the full SDK for your programming language, start at
+:rax-dev:`SDKs & Tools in the Developer Center <sdks>`
+and find the language.
 Then follow the steps appropriate to that language.
 
-For example, if you code in python, 
+For example, if you code in python,
 
-* Follow the installation instructions to give yourself 
-  a local copy of the pyrax (python for Rackspace) SDK. 
-* Click **documentation** to open the 
-  `GitHub repository for the pyrax SDK <https://github.com/rackspace/pyrax/>`__. 
-* In that pyrax repository, at 
+* Follow the installation instructions to give yourself
+  a local copy of the pyrax (python for Rackspace) SDK.
+* Click **documentation** to open the
+  `GitHub repository for the pyrax SDK <https://github.com/rackspace/pyrax/>`__.
+* In that pyrax repository, at
   `/docs/ <https://github.com/rackspace/pyrax/tree/master/docs>`__,
-  you can see documents specific to 
-  three of the four core infrastructure services: 
-  Cloud Servers, Cloud Networks, Cloud Block Storage. 
-  Although no document is specific to Cloud Images, 
-  you can adapt the examples in one of the others.  
+  you can see documents specific to
+  three of the four core infrastructure services:
+  Cloud Servers, Cloud Networks, Cloud Block Storage.
+  Although no document is specific to Cloud Images,
+  you can adapt the examples in one of the others.

--- a/cloud-interfaces/gui/cloudblockstorage-gui.rst
+++ b/cloud-interfaces/gui/cloudblockstorage-gui.rst
@@ -3,21 +3,21 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Cloud Block Storage and the Cloud Control Panel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The Cloud Control Panel groups the core infrastructure services 
-as described at :ref:`cloud-tour`, 
-with 
-Cloud Block Storage (labeled **Block Storage Volumes**) 
-available 
-under **Storage**. 
+The Cloud Control Panel groups the core infrastructure services
+as described at :ref:`cloud-tour`,
+with
+Cloud Block Storage (labeled **Block Storage Volumes**)
+available
+under **Storage**.
 
 .. figure:: /_images/StorageGroup.png
    :scale: 80%
-   :alt: The Storage group includes Cloud Block Storage. 
-   
-   *The Storage group includes Cloud Block Storage.* 
+   :alt: The Storage group includes Cloud Block Storage.
 
-You can use the Cloud Control Panel to help you 
-observe and manage your Cloud Block Storage configuration. 
-For ideas about what to do first, 
-visit 
-`Getting Started With Cloud Block Storage <http://www.rackspace.com/knowledge_center/getting-started/cloud-block-storage>`__.
+   *The Storage group includes Cloud Block Storage.*
+
+You can use the Cloud Control Panel to help you
+observe and manage your Cloud Block Storage configuration.
+For ideas about what to do first,
+visit
+:kc-article:`Getting Started with Cloud Block Storage <getting-started/cloud-block-storage>`.

--- a/cloud-interfaces/gui/cloudimages-gui.rst
+++ b/cloud-interfaces/gui/cloudimages-gui.rst
@@ -3,22 +3,22 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Cloud Images and the Cloud Control Panel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The Cloud Control Panel groups the core infrastructure services 
-as described at :ref:`cloud-tour`, 
-with 
-Cloud Servers (labeled **Cloud Servers**) 
-and Cloud Images (labeled **Saved Images**) both available 
-under **Servers**. 
+The Cloud Control Panel groups the core infrastructure services
+as described at :ref:`cloud-tour`,
+with
+Cloud Servers (labeled **Cloud Servers**)
+and Cloud Images (labeled **Saved Images**) both available
+under **Servers**.
 
 .. figure:: /_images/ServersGroup.png
-   :alt: The Servers group includes Cloud Servers and 
-         Cloud Images.  
-         
-   *The Servers group includes Cloud Servers and 
-   Cloud Images.*     
+   :alt: The Servers group includes Cloud Servers and
+         Cloud Images.
 
-You can use the Cloud Control Panel to help you 
-observe and manage your Cloud Images configuration. 
-For ideas about what to do first, 
-visit 
-`Getting Started With Rackspace Cloud Images <http://www.rackspace.com/knowledge_center/getting-started/cloud-images>`__.
+   *The Servers group includes Cloud Servers and
+   Cloud Images.*
+
+You can use the Cloud Control Panel to help you
+observe and manage your Cloud Images configuration.
+For ideas about what to do first,
+visit
+:kc:`Getting Started with Rackspace Cloud Images <getting-started/cloud-images>`.

--- a/cloud-interfaces/gui/cloudnetworks-gui.rst
+++ b/cloud-interfaces/gui/cloudnetworks-gui.rst
@@ -3,21 +3,21 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Cloud Networks and the Cloud Control Panel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The Cloud Control Panel groups the core infrastructure services 
-as described at :ref:`cloud-tour`, 
-with 
-Cloud Networks (labeled **Networks**) 
-available 
-under **Networking**. 
+The Cloud Control Panel groups the core infrastructure services
+as described at :ref:`cloud-tour`,
+with
+Cloud Networks (labeled **Networks**)
+available
+under **Networking**.
 
 .. figure:: /_images/NetworkingGroup.png
    :scale: 80%
-   :alt: The Networking group includes Cloud Networks.  
-   
-   *The Networking group includes Cloud Networks.* 
+   :alt: The Networking group includes Cloud Networks.
 
-You can use the Cloud Control Panel to help you 
-observe and manage your Cloud Networks configuration. 
-For ideas about what to do first, 
-visit 
-`Getting Started with Cloud Networks <http://www.rackspace.com/knowledge_center/article/getting-started-with-cloud-networks>`__.
+   *The Networking group includes Cloud Networks.*
+
+You can use the Cloud Control Panel to help you
+observe and manage your Cloud Networks configuration.
+For ideas about what to do first,
+visit
+:kc-article:`Getting Started with Cloud Networks <getting-started-with-cloud-networks>`.

--- a/cloud-interfaces/gui/cloudservers-gui.rst
+++ b/cloud-interfaces/gui/cloudservers-gui.rst
@@ -3,23 +3,23 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Cloud Servers and the Cloud Control Panel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The Cloud Control Panel groups the core infrastructure services 
-as described at :ref:`cloud-tour`, 
-with 
-Cloud Servers (labeled **Cloud Servers**) 
-and Cloud Images (labeled **Saved Images**) both available 
-under **Servers**. 
+The Cloud Control Panel groups the core infrastructure services
+as described at :ref:`cloud-tour`,
+with
+Cloud Servers (labeled **Cloud Servers**)
+and Cloud Images (labeled **Saved Images**) both available
+under **Servers**.
 
 .. figure:: /_images/ServersGroup.png
    :scale: 80%
-   :alt: The Servers group includes Cloud Servers and 
+   :alt: The Servers group includes Cloud Servers and
          Cloud Images.
-         
-   *The Servers group includes Cloud Servers and 
-   Cloud Images.*   
 
-You can use the Cloud Control Panel to help you 
-observe and manage your Cloud Servers configuration. 
-For ideas about what to do first, 
-visit 
-`Getting Started with Cloud Servers <http://www.rackspace.com/knowledge_center/getting-started/cloud-servers>`__.
+   *The Servers group includes Cloud Servers and
+   Cloud Images.*
+
+You can use the Cloud Control Panel to help you
+observe and manage your Cloud Servers configuration.
+For ideas about what to do first,
+visit
+:kc:`Getting Started with Cloud Servers <getting-started/cloud-servers>`.

--- a/cloud-interfaces/gui/index.rst
+++ b/cloud-interfaces/gui/index.rst
@@ -8,7 +8,7 @@ the easiest way to get started with provisioning cloud resources.
 
 The Cloud Control Panel provides a simple, unified web based interface
 that works in all major browsers. After signing up for a Cloud account
-at `rackspace.com <http://www.rackspace.com/>`__, the Cloud Control panel is the first place you 
+at `rackspace.com <http://www.rackspace.com/>`__, the Cloud Control panel is the first place you
 should visit to get an overview of products and services available,
 create your first servers and resources, or view more information about
 your Rackspace account.
@@ -16,24 +16,24 @@ your Rackspace account.
 The Cloud Control Panel is also where you can complete some important
 first tasks:
 
-* `Obtain your API key <http://www.rackspace.com/knowledge_center/article/view-and-reset-your-api-key>`__
-  for use with 
-  :ref:`CLIs <cloud-interfaces-cli>`, 
-  :ref:`SDKs <sdk>`, 
-  and 
+* :kc-article:`Obtain your API key <view-and-reset-your-api-key>`
+  for use with
+  :ref:`CLIs <cloud-interfaces-cli>`,
+  :ref:`SDKs <sdk>`,
+  and
   :ref:`APIs <direct-api-access>`
 
-* `Create additional account users <http://www.rackspace.com/knowledge_center/article/managing-role-based-access-control-rbac>`__ 
-  and give them 
-  `permissions <http://www.rackspace.com/knowledge_center/article/permissions-matrix-for-role-based-access-control-rbac>`__ 
+* :kc-article:`Create additional account users <managing-role-based-access-control-rbac>`
+  and give them
+  :kc-article:`permissions <permissions-matrix-for-role-based-access-control-rbac>`
   if needed
 
   .. note::
-     Users who do not have permission to use a feature 
-     do not see that feature in the Cloud Control Panel. 
-     Cloud Control Panel screenshots in 
-     `technical documentation <http://www.rackspace.com/knowledge_center/>`__ 
-     may show features that are not 
+     Users who do not have permission to use a feature
+     do not see that feature in the Cloud Control Panel.
+     Cloud Control Panel screenshots in
+     `technical documentation <http://www.rackspace.com/knowledge_center/>`__
+     may show features that are not
      available to some users.
 
 * View and change resource limits
@@ -42,34 +42,34 @@ first tasks:
      :scale: 80%
      :alt: Use the Control Panel to see your current
          limits and to ask to change them.
-         
+
      *Use the Control Panel to see your current
      limits and to ask to change them.*
-         
+
   If you click the **Request Limit Increase** link, the system will
-  generate a ticket with details of your current limits filled in. 
-  Making a change requires describing the change you want and 
-  submitting the ticket for processing. Update the ticket to 
-  describe the change you want; then click **Submit Ticket**. 
- 
+  generate a ticket with details of your current limits filled in.
+  Making a change requires describing the change you want and
+  submitting the ticket for processing. Update the ticket to
+  describe the change you want; then click **Submit Ticket**.
+
   .. figure:: /_images/CreateTicketServersResourceLimit.png
      :scale: 80%
-     :alt: In the generated ticket, 
-         fill in the details you want to change. 
-         
-     *In the generated ticket, 
+     :alt: In the generated ticket,
+         fill in the details you want to change.
+
+     *In the generated ticket,
      fill in the details you want to change.*
- 
+
 The Cloud Control Panel may be the only interface you need to use,
 especially if you don't need to heavily automate the management of your
 cloud resources.
 
 .. note::
    Under unusual circumstances,
-   high-priority messages may be displayed in a banner 
-   at the top of your Cloud Control Panel pages. 
-   If you see such a message, 
-   follow its instructions as soon as you can. 
+   high-priority messages may be displayed in a banner
+   at the top of your Cloud Control Panel pages.
+   If you see such a message,
+   follow its instructions as soon as you can.
 
 
 

--- a/cloud-interfaces/gui/moreinfo-gui.rst
+++ b/cloud-interfaces/gui/moreinfo-gui.rst
@@ -3,41 +3,40 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Learning more about the Cloud Control Panel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Every cloud account comes with access to the 
-`Cloud Control Panel <https://mycloud.rackspace.com/>`__. 
-Depending on how you use your Rackspace account, 
-you may not be interested in changes to specific  
-Rackspace cloud products and services. 
-However, the Cloud Control Panel is common ground, 
-available to all Rackspace cloud customers, 
-and we recommend that all Rackspace customers pay attention 
-to ongoing development there. 
+Every cloud account comes with access to the
+`Cloud Control Panel <https://mycloud.rackspace.com/>`__.
+Depending on how you use your Rackspace account,
+you may not be interested in changes to specific
+Rackspace cloud products and services.
+However, the Cloud Control Panel is common ground,
+available to all Rackspace cloud customers,
+and we recommend that all Rackspace customers pay attention
+to ongoing development there.
 
-Making yourself familiar with these sites 
-and keeping up with new information there 
-will 
+Making yourself familiar with these sites
+and keeping up with new information there
+will
 help you become a skillful user of the Cloud Control Panel:
 
-* **Technical documentation** 
-  focused on the Cloud Control Panel, 
-  including short tutorials and demonstrations, is 
-  published in the 
-  `Rackspace Knowledge Center <http://www.rackspace.com/knowledge_center/>`__. 
+* **Technical documentation**
+  focused on the Cloud Control Panel,
+  including short tutorials and demonstrations, is
+  published in the :kc:`Rackspace Knowledge Center <>`. 
 
-* **Announcements of major changes** 
-  are published 
-  in 
+* **Announcements of major changes**
+  are published
+  in
   `Release Notes <https://mycloud.rackspace.com/release_notes>`__.
-  
-  .. note::
-     We continuously improve the Cloud Control Panel;  
-     you may see minor changes between one visit and the next. 
-     We announce only major changes in Release Notes. 
 
-* **Discussions with customers and Rackers** 
-  are open to public participation in the 
+  .. note::
+     We continuously improve the Cloud Control Panel;
+     you may see minor changes between one visit and the next.
+     We announce only major changes in Release Notes.
+
+* **Discussions with customers and Rackers**
+  are open to public participation in the
   `Rackspace Community <https://community.rackspace.com/>`__.
 
-* **Feedback on proposed improvements to the Cloud Control Panel** 
-  is open to public partication at 
-  `Rackspace Product Feedback <https://feedback.rackspace.com/>`__. 
+* **Feedback on proposed improvements to the Cloud Control Panel**
+  is open to public partication at
+  `Rackspace Product Feedback <https://feedback.rackspace.com/>`__.

--- a/cloud-intro/cloud-tour/application-services.rst
+++ b/cloud-intro/cloud-tour/application-services.rst
@@ -12,56 +12,55 @@ Services in this category include
 
 Auto Scale at a glance
 ~~~~~~~~~~~~~~~~~~~~~~
-+---------------------------------------+------------------------------------------------+
-|                                       |                                                |
-| .. image::                            | * `Product overview                            |
-|    /_images/logo-autoscale-50x50.png  |   <http://www.rackspace.com/cloud/             |
-|    :alt: Auto Scale meets             |   auto-scale>`__                               |
-|          user demand.                 | * Free with every cloud account                |
-|    :align: center                     | * Open-source roots:                           |
-|                                       |   `Otter <https://github.com/rackerlabs/       |
-| Auto Scale meets                      |   otter>`__                                    |
-| user demand.                          |                                                |
-+---------------------------------------+------------------------------------------------+
++------------------------------------------------+------------------------------------------------+
+|                                                |                                                |
+| .. image::                                     | * :rax-cloud:`Product overview <auto-scale>`   |
+|    /_images/logo-autoscale-50x50.png           | * Free with every cloud account                |
+|    :alt: Auto Scale meets                      | * Open-source roots:                           |
+|          user demand.                          |   :rackerlabs:`Otter <otter>`                  |
+|    :align: center                              |                                                |
+|                                                |                                                |
+| Auto Scale meets user demand.                  |                                                |
++------------------------------------------------+------------------------------------------------+
 
 Cloud Metrics at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-+--------------------------------------------+---------------------------------------------+
-|                                            |                                             |
-| .. image::                                 | * `Product overview                         |
-|    /_images/logo-cloudmetrics-50x50.png    |   <http://www.rackspace.com/                |
-|    :alt: Cloud Metrics stores and serves   |   knowledge_center/article/                 |
-|          time-series metrics.              |   cloud-metrics-overview>`__                |
-|    :align: center                          | * Free with every cloud account             |
-|                                            | * Open-source roots:                        |
-| Cloud Metrics stores and serves            |   `Blueflood <http://blueflood.io/>`__      |
-| time-series metrics.                       |                                             |
-+--------------------------------------------+---------------------------------------------+
++------------------------------------------------+------------------------------------------------+
+|                                                |                                                |
+| .. image::                                     | * :kc-article:`Product overview                |
+|    /_images/logo-cloudmetrics-50x50.png        |   <cloud-metrics-overview>`                    |
+|    :alt: Cloud Metrics stores and serves       | * Free with every cloud account                |
+|          time-series metrics.                  | * Open-source roots:                           |
+|    :align: center                              |   `Blueflood <http://blueflood.io/>`__         |
+|                                                |                                                |
+| Cloud Metrics stores and serves                |                                                |
+| time-series metrics.                           |                                                |
++------------------------------------------------+------------------------------------------------+
 
 Cloud Monitoring at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-+---------------------------------------------+-------------------------------------------------------+
-|                                             |                                                       |
-| .. image::                                  | * `Product overview                                   |
-|    /_images/logo-cloudmonitoring-50x50.png  |   <http://www.rackspace.com/cloud/                    |
-|    :alt: Cloud Monitoring monitors          |   monitoring>`__                                      |
-|          the infrastructure.                | * Free with every cloud account                       |
-|    :align: center                           | * Open-source roots:                                  |
-|                                             |   `Virgo <https://github.com/virgo-agent-toolkit>`__  |
-| Cloud Monitoring monitors                   |                                                       |
-| the infrastructure.                         |                                                       |
-+---------------------------------------------+-------------------------------------------------------+
++------------------------------------------------+------------------------------------------------+
+|                                                |                                                |
+| .. image::                                     | * :rax-cloud:`Product overview <monitoring>`   |
+|    /_images/logo-cloudmonitoring-50x50.png     | * Free with every cloud account                |
+|    :alt: Cloud Monitoring monitors             | * Open-source roots:                           |
+|          the infrastructure.                   |   `Virgo                                       |
+|    :align: center                              |   <https://github.com/virgo-agent-toolkit>`__  |
+|                                                |                                                |
+| Cloud Monitoring monitors                      |                                                |
+| the infrastructure.                            |                                                |
++------------------------------------------------+------------------------------------------------+
 
 Cloud Orchestration at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 +------------------------------------------------+-------------------------------------------------+
 |                                                |                                                 |
-| .. image::                                     | * `Product overview                             |
-|    /_images/logo-cloudorchestration-50x50.png  |   <http://www.rackspace.com/cloud/              |
-|    :alt: Cloud Orchestration automates         |   orchestration>`__                             |
-|          and standardizes infrastructure.      | * Free with every cloud account                 |
-|    :align: center                              | * Open-source roots:                            |
-|                                                |   `OpenStack Heat <http://docs.openstack.org/   |
-| Cloud Orchestration automates                  |   developer/heat/>`__                           |
+| .. image::                                     | * :rax-cloud:`Product overview <orchestration>` |
+|    /_images/logo-cloudorchestration-50x50.png  | * Free with every cloud account                 |
+|    :alt: Cloud Orchestration automates         | * Open-source roots:                            |
+|          and standardizes infrastructure.      |   :os-docs:`OpenStack Heat <developer/heat>`    |
+|    :align: center                              |                                                 |
+|                                                |                                                 |
+| Cloud Orchestration automates                  |                                                 |
 | and standardizes infrastructure.               |                                                 |
 +------------------------------------------------+-------------------------------------------------+

--- a/cloud-intro/cloud-tour/compute-services.rst
+++ b/cloud-intro/cloud-tour/compute-services.rst
@@ -5,28 +5,28 @@ Compute services
 ----------------
 Services in this category include
 
-* Cloud Servers 
+* Cloud Servers
 * Cloud Images
 
 Cloud Servers at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-+-------------------------------------------+------------------------------------------------+
-|                                           |                                                |
-| .. image::                                | * `Product overview                            |
-|    /_images/logo-cloudservers-50x50.png   |   <http://www.rackspace.com/cloud/servers>`__  |
-|    :alt: Cloud Servers provides           | * `Pay only for what you use                   |
-|          computing power.                 |   <http://www.rackspace.com/cloud/             |
-|    :align: center                         |   public-pricing>`__                           |
-|                                           | * Open-source roots:                           |
-| Cloud Servers provides                    |   `OpenStack Nova <http://docs.openstack.org/  |
-| computing power.                          |   developer/nova/>`__                          |
-+-------------------------------------------+------------------------------------------------+
++-------------------------------------------+--------------------------------------------------+
+|                                           |                                                  |
+| .. image::                                | * :rax-cloud:`Product overview <servers>`        |
+|    /_images/logo-cloudservers-50x50.png   | * :rax-cloud:`Pay only for what you use          |
+|    :alt: Cloud Servers provides           |   <public-pricing>`                              |
+|          computing power.                 | * Open-source roots:                             |
+|    :align: center                         |   :os-docs:`OpenStack Nova <developer/nova>`     |
+|                                           |                                                  |
+| Cloud Servers provides                    |                                                  |
+| computing power.                          |                                                  |
++-------------------------------------------+--------------------------------------------------+
 
 .. TIP::
-   Cloud Servers is part of the 
-   core infrastructure of the Rackspace cloud, 
-   the focus of this guide. 
-   
+   Cloud Servers is part of the
+   core infrastructure of the Rackspace cloud,
+   the focus of this guide.
+
    A good place to begin learning to interact with it is
    :ref:`cloud_interfaces`.
 
@@ -34,21 +34,20 @@ Cloud Images at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~
 +-------------------------------------------+--------------------------------------------------+
 |                                           |                                                  |
-| .. image::                                | * `Product overview                              |
-|    /_images/logo-cloudimages-50x50.png    |   <http://www.rackspace.com/cloud/images>`__     |
-|    :alt: Cloud images standardizes        | * `Pay only for what you use                     |
-|          cloud server creation.           |   <http://www.rackspace.com/cloud/               |
-|    :align: center                         |   public-pricing>`__                             |
-|                                           | * Open-source roots:                             |
-| Cloud Images standardizes                 |   `OpenStack Glance <http://docs.openstack.org/  |
-| cloud server creation.                    |   developer/glance/>`__                          |
+| .. image::                                | * :rax-cloud:`Product overview <images>`         |
+|    /_images/logo-cloudimages-50x50.png    | * :rax-cloud:`Pay only for what you use          |
+|    :alt: Cloud images standardizes        |   <public-pricing>`                              |
+|          cloud server creation.           | * Open-source roots:                             |
+|    :align: center                         |   :os-docs:`OpenStack Glance <developer/glance>` |
+|                                           |                                                  |
+| Cloud Images standardizes                 |                                                  |
+| cloud server creation.                    |                                                  |
 +-------------------------------------------+--------------------------------------------------+
-  
+
 .. TIP::
-   Cloud Images is part of the 
-   core infrastructure of the Rackspace cloud, 
-   the focus of this guide. 
-   
+   Cloud Images is part of the
+   core infrastructure of the Rackspace cloud,
+   the focus of this guide.
+
    A good place to begin learning to interact with it is
    :ref:`cloud_interfaces`.
-

--- a/cloud-intro/cloud-tour/data-services.rst
+++ b/cloud-intro/cloud-tour/data-services.rst
@@ -5,63 +5,62 @@ Data services
 -------------
 Services in this category include
 
-* Cloud Big Data 
+* Cloud Big Data
 * Cloud Databases
-* Object Rocket 
+* Object Rocket
 
 Cloud Big Data at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-+--------------------------------------------+---------------------------------------------+
-|                                            |                                             |
-| .. image::                                 | * `Product overview                         |
-|    /_images/logo-cloudbigdata-50x50.png    |   <http://www.rackspace.com/cloud/          |
-|    :alt: Cloud Big Data manages Apache     |   big-data>`__                              |
-|          Hadoop environments.              | * `Pay only for what you use                |
-|    :align: center                          |   <http://www.rackspace.com/cloud/          |
-|                                            |   public-pricing>`__                        |
-| Cloud Big Data manages Apache              |                                             |
-| Hadoop environments.                       |                                             |
-+--------------------------------------------+---------------------------------------------+
++--------------------------------------------+--------------------------------------------------+
+|                                            |                                                  |
+| .. image::                                 | * :rax-cloud:`Product overview <big-data>`       |
+|    /_images/logo-cloudbigdata-50x50.png    | * :rax-cloud:`Pay only for what you use          |
+|    :alt: Cloud Big Data manages Apache     |   <public-pricing>`                              |
+|          Hadoop environments.              |                                                  |
+|    :align: center                          |                                                  |
+|                                            |                                                  |
+| Cloud Big Data manages Apache              |                                                  |
+| Hadoop environments.                       |                                                  |
++--------------------------------------------+--------------------------------------------------+
 
 .. TIP::
-   Cloud Big Data is the right tool for 
+   Cloud Big Data is the right tool for
    Hadoop.
 
 Cloud Databases at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-+--------------------------------------------+------------------------------------------------+
-|                                            |                                                |
-| .. image::                                 | * `Product overview                            |
-|    /_images/logo-clouddatabases-50x50.png  |   <http://www.rackspace.com/cloud/             |
-|    :alt: Cloud Databases provides          |   big-data>`__                                 |
-|          on-demand provisioning and        | * `Pay only for what you use                   |
-|          open APIs.                        |   <http://www.rackspace.com/cloud/             |
-|    :align: center                          |   public-pricing>`__                           |
-|                                            | * Open-source roots:                           |
-| Cloud Databases provides on-demand         |   `OpenStack Trove <http://docs.openstack.org/ |
-| provisioning and open APIs.                |   developer/trove/>`__                         |
-+--------------------------------------------+------------------------------------------------+ 
++--------------------------------------------+--------------------------------------------------+
+|                                            |                                                  |
+| .. image::                                 | * :rax-cloud:`Product overview <databases>`      |
+|    /_images/logo-clouddatabases-50x50.png  | * :rax-cloud:`Pay only for what you use          |
+|    :alt: Cloud Databases provides          |   <public-pricing>`                              |
+|          on-demand provisioning and        | * Open-source roots:                             |
+|          open APIs.                        |   :os-docs:`OpenStack Trove <developer/trove>`   |
+|    :align: center                          |                                                  |
+|                                            |                                                  |
+| Cloud Databases provides on-demand         |                                                  |
+| provisioning and open APIs.                |                                                  |
++--------------------------------------------+--------------------------------------------------+
 
 .. TIP::
-   Cloud Databases is the right tool for 
+   Cloud Databases is the right tool for
    MySQL, Percona Server, and MariaDB.
 
 Object Rocket at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-+--------------------------------------------+------------------------------------------------+
-|                                            |                                                |
-| .. image::                                 | * `Product overview                            |
-|    /_images/logo-objectrocket-50x50.png    |   <https://objectrocket.com/features>`__       |
-|    :alt: Cloud Databases provides          | * `Pay only for what you use                   |
-|          on-demand provisioning and        |   <https://objectrocket.com/pricing>`__        |
-|          open APIs.                        | * Open-source roots:                           |
-|    :align: center                          |   `Object Rocket                               |
-|                                            |   <https://objectrocket.com/>`__               |
-| Object Rocket provides                     |                                                |
-| managed instances of MongoDB and Redis.    |                                                |
-+--------------------------------------------+------------------------------------------------+ 
++--------------------------------------------+--------------------------------------------------+
+|                                            |                                                  |
+| .. image::                                 | * :rocket:`Product overview <features>`          |
+|    /_images/logo-objectrocket-50x50.png    | * :rocket:`Pay only for what you use <pricing>`  |
+|    :alt: Cloud Databases provides          | * Open-source roots:                             |
+|          on-demand provisioning and        |   :rocket:`Object Rocket <>`                     |
+|          open APIs.                        |                                                  |
+|    :align: center                          |                                                  |
+|                                            |                                                  |
+| Object Rocket provides                     |                                                  |
+| managed instances of MongoDB and Redis.    |                                                  |
++--------------------------------------------+--------------------------------------------------+
 
 .. TIP::
-   Object Rocket is the right tool for 
+   Object Rocket is the right tool for
    MongoDB and Redis.
-

--- a/cloud-intro/cloud-tour/network-services.rst
+++ b/cloud-intro/cloud-tour/network-services.rst
@@ -5,7 +5,7 @@ Network services
 ----------------
 Services in this category include
 
-* Cloud Networks 
+* Cloud Networks
 * Cloud DNS
 * Cloud Load Balancers
 * RackConnect
@@ -14,38 +14,38 @@ Cloud Networks at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 +-------------------------------------------+---------------------------------------------------+
 |                                           |                                                   |
-| .. image::                                | * `Product overview                               |
-|    /_images/logo-cloudnetworks-50x50.png  |   <http://www.rackspace.com/cloud/networks>`__    |
-|    :alt: Cloud Networks connects          | * Free with every cloud account                   |
-|          Cloud Servers.                   | * Open-source roots:                              |
-|    :align: center                         |   `OpenStack Neutron <https://wiki.openstack.org/ |
-|                                           |   wiki/Neutron>`__                                |
+| .. image::                                | * :rax-cloud:`Product overview <networks>`        |
+|    /_images/logo-cloudnetworks-50x50.png  | * Free with every cloud account                   |
+|    :alt: Cloud Networks connects          | * Open-source roots:                              |
+|          Cloud Servers.                   |   :os-wiki:`OpenStack Neutron <wiki/Neutron>`     |
+|    :align: center                         |                                                   |
+|                                           |                                                   |
 | Cloud Networks connects                   |                                                   |
 | Cloud Servers.                            |                                                   |
 +-------------------------------------------+---------------------------------------------------+
 
 Cloud Networks enables customers to create and manage secure, isolated
-networks in the cloud. 
+networks in the cloud.
 These networks are fully single-tenant, and
-customers have complete control over the network topology, 
-IP addressing (IPv4 or IPv6), 
+customers have complete control over the network topology,
+IP addressing (IPv4 or IPv6),
 and which Cloud Servers are connected to the network.
 
 .. TIP::
-   Cloud Networks is part of the 
-   core infrastructure of the Rackspace cloud, 
-   the focus of this guide. 
-   
+   Cloud Networks is part of the
+   core infrastructure of the Rackspace cloud,
+   the focus of this guide.
+
    A good place to begin learning to interact with it is
-   :ref:`cloud_interfaces`. 
+   :ref:`cloud_interfaces`.
 
 Cloud DNS at a glance
 ~~~~~~~~~~~~~~~~~~~~~
 +-------------------------------------------+---------------------------------------------------+
 |                                           |                                                   |
-| .. image::                                | * `Product overview                               |
-|    /_images/logo-clouddns-50x50.png       |   <http://www.rackspace.com/cloud/dns>`__         |
-|    :alt: Cloud DNS manages DNS            | * Free with every cloud account                   |
+| .. image::                                | * :rax-cloud:`Product overview <dns>`             |
+|    /_images/logo-clouddns-50x50.png       | * Free with every cloud account                   |
+|    :alt: Cloud DNS manages DNS            |                                                   |
 |          services for domains.            |                                                   |
 |    :align: center                         |                                                   |
 |                                           |                                                   |
@@ -57,12 +57,12 @@ Cloud Load Balancers at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 +-----------------------------------------------+---------------------------------------------------+
 |                                               |                                                   |
-| .. image::                                    | * `Product overview                               |
-|    /_images/logo-cloudloadbalancers-50x50.png |   <http://www.rackspace.com/cloud/                |
-|    :alt: Cloud Load Balancers distribute      |   load-balancing>`__                              |
-|          workloads across multiple            | * `Pay only for what you use                      |
-|          servers.                             |   <http://www.rackspace.com/cloud/                |
-|    :align: center                             |   public-pricing>`__                              |
+| .. image::                                    | * :rax-cloud:`Product overview <load-balancing>`  |
+|    /_images/logo-cloudloadbalancers-50x50.png | * :rax-cloud:`Pay only for what you use           |
+|    :alt: Cloud Load Balancers distribute      |   <public-pricing>`                               |
+|          workloads across multiple            |                                                   |
+|          servers.                             |                                                   |
+|    :align: center                             |                                                   |
 |                                               |                                                   |
 | Cloud Load Balancers distribute workloads     |                                                   |
 | across multiple servers.                      |                                                   |
@@ -70,16 +70,15 @@ Cloud Load Balancers at a glance
 
 RackConnect at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~
-+-------------------------------------------+---------------------------------------------------+
-|                                           |                                                   |
-| .. image::                                | * `Product overview                               |
-|    /_images/logo-rackconnect-50x50.png    |   <http://www.rackspace.com/cloud/hybrid/         |
-|    :alt: RackConnect connects             |   rackconnect>`__                                 |
-|          dedicated servers to             | * `Pay only for what you use                      |
-|          the managed cloud.               |   <http://www.rackspace.com/cloud/                |
-|    :align: center                         |   public-pricing>`__                              |
-|                                           |                                                   |
-| RackConnect connects dedicated            |                                                   |
-| servers to the managed cloud.             |                                                   |
-+-------------------------------------------+---------------------------------------------------+
-
++-------------------------------------------+------------------------------------------------------+
+|                                           |                                                      |
+| .. image::                                | * :rax-cloud:`Product overview <hybrid/rackconnect>` |
+|    /_images/logo-rackconnect-50x50.png    | * :rax-cloud:`Pay only for what you use              |
+|    :alt: RackConnect connects             |   <public-pricing>`                                  |
+|          dedicated servers to             |                                                      |
+|          the managed cloud.               |                                                      |
+|    :align: center                         |                                                      |
+|                                           |                                                      |
+| RackConnect connects dedicated            |                                                      |
+| servers to the managed cloud.             |                                                      |
++-------------------------------------------+------------------------------------------------------+

--- a/cloud-intro/cloud-tour/storage-services.rst
+++ b/cloud-intro/cloud-tour/storage-services.rst
@@ -14,15 +14,14 @@ Cloud Block Storage at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 +-------------------------------------------------+--------------------------------------------------+
 |                                                 |                                                  |
-| .. image::                                      | * `Product overview                              |
-|    /_images/logo-cloudblockstorage-50x50.png    |   <http://www.rackspace.com/cloud/               |
-|    :alt: Cloud Block Storage adds               |   block-storage>`__                              |
-|          cloud server storage.                  | * `Pay only for what you use                     |
-|    :align: center                               |   <http://www.rackspace.com/cloud/               |
-|                                                 |   public-pricing>`__                             |
-| Cloud Block Storage adds                        | * Open-source roots:                             |
-| cloud server storage.                           |   `OpenStack Cinder <http://docs.openstack.org/  |
-|                                                 |   developer/cinder/>`__                          |
+| .. image::                                      | * :rax-cloud:`Product overview <block-storage>`  |
+|    /_images/logo-cloudblockstorage-50x50.png    | * :rax-cloud:`Pay only for what you use          |
+|    :alt: Cloud Block Storage adds               |   <public-pricing>`                              |
+|          cloud server storage.                  | * Open-source roots:                             |
+|    :align: center                               |   :os-docs:`OpenStack Cinder <developer/cinder>` |
+|                                                 |                                                  |
+| Cloud Block Storage adds                        |                                                  |
+| cloud server storage.                           |                                                  |
 +-------------------------------------------------+--------------------------------------------------+
 
 .. TIP::
@@ -37,11 +36,11 @@ Cloud Backup at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~
 +-------------------------------------------+-------------------------------------------------+
 |                                           |                                                 |
-| .. image::                                | * `Product overview                             |
-|    /_images/logo-cloudbackup-50x50.png    |   <http://www.rackspace.com/cloud/backup>`__    |
-|    :alt: Cloud Backup safeguards          | * `Pay only for what you use                    |
-|          data.                            |   <http://www.rackspace.com/cloud/              |
-|    :align: center                         |   public-pricing>`__                            |
+| .. image::                                | * :rax-cloud:`Product overview <backup>`        |
+|    /_images/logo-cloudbackup-50x50.png    | * :rax-cloud:`Pay only for what you use         |
+|    :alt: Cloud Backup safeguards          |   <public-pricing>`                             |
+|          data.                            |                                                 |
+|    :align: center                         |                                                 |
 |                                           |                                                 |
 | Cloud Backup safeguards                   |                                                 |
 | data.                                     |                                                 |
@@ -51,12 +50,12 @@ Cloud CDN at a glance
 ~~~~~~~~~~~~~~~~~~~~~
 +-------------------------------------------+-------------------------------------------------+
 |                                           |                                                 |
-| .. image::                                | * `Product overview                             |
-|    /_images/logo-cloudcdn-50x50.png       |   <http://www.rackspace.com/cloud/              |
-|    :alt: Cloud CDN accelerates            |   cdn-content-delivery-network>`__              |
-|          content delivery.                | * `Pay only for what you use                    |
-|    :align: center                         |   <http://www.rackspace.com/cloud/              |
-|                                           |   public-pricing>`__                            |
+| .. image::                                | * :rax-cloud:`Product overview                  |
+|    /_images/logo-cloudcdn-50x50.png       |   <cdn-content-delivery-network>`               |
+|    :alt: Cloud CDN accelerates            | * :rax-cloud:`Pay only for what you use         |
+|          content delivery.                |   <public-pricing>`                             |
+|    :align: center                         |                                                 |
+|                                           |                                                 |
 | Cloud CDN accelerates                     |                                                 |
 | content delivery.                         |                                                 |
 +-------------------------------------------+-------------------------------------------------+
@@ -65,12 +64,12 @@ Cloud Files at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~
 +--------------------------------------------+--------------------------------------------------+
 |                                            |                                                  |
-| .. image::                                 | * `Product overview                              |
-|    /_images/logo-cloudfiles-50x50.png      |   <http://www.rackspace.com/cloud/files>`__      |
-|    :alt: Cloud Files stores                | * `Pay only for what you use                     |
-|          online objects                    |   <http://www.rackspace.com/cloud/               |
-|    :align: center                          |   public-pricing>`__                             |
-|                                            | * Open-source roots:                             |
-| Cloud Files stores                         |   `OpenStack Swift <http://docs.openstack.org/   |
-| online objects.                            |   developer/swift/>`__                           |
+| .. image::                                 | * :rax-cloud:`Produce overview <files>`          |
+|    /_images/logo-cloudfiles-50x50.png      | * :rax-cloud:`Pay only for what you use          |
+|    :alt: Cloud Files stores                |   <public-pricing>`                              |
+|          online objects                    | * Open-source roots:                             |
+|    :align: center                          |   :os-docs:`OpenStack Swift <developer/swift>`   |
+|                                            |                                                  |
+| Cloud Files stores                         |                                                  |
+| online objects.                            |                                                  |
 +--------------------------------------------+--------------------------------------------------+

--- a/cloud-intro/cloud-tour/support-services.rst
+++ b/cloud-intro/cloud-tour/support-services.rst
@@ -5,40 +5,40 @@ Security and supporting services
 --------------------------------
 Services in this category include
 
-* Cloud Feeds 
-* Rackspace Identity 
+* Cloud Feeds
+* Rackspace Identity
 
 Cloud Feeds at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 * `Product overview <http://www.rackspace.com/knowledge_center/article/cloud-feeds-overview>`__
-  
-* Free with every cloud account 
-  
-* Open-source roots: 
+
+* Free with every cloud account
+
+* Open-source roots:
   `Atom Hopper <http://atomhopper.org/>`__
 
 Cloud Feeds provides API access to events emitted from your infrastructure
-resources. 
+resources.
 With Cloud Feeds, you can track usage right now.
-You can see *access events* (for example, who changed what server via control plane at what point) and 
+You can see *access events* (for example, who changed what server via control plane at what point) and
 *state transition events* (for example, when did a load balancer's status go to 'draining').
 
 Rackspace Identity at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 +---------------------------------------------+-------------------------------------------------------+
 |                                             |                                                       |
-| .. image::                                  | * `Product overview                                   |
-|    /_images/logo-cloudidentity-50x50.png    |   <http://www.rackspace.com/knowledge_center/article/ |
-|    :alt: Rackspace Identity                 |   managing-role-based-access-control-rbac>`__         |
-|          manages authentication.            | * Free with every cloud account                       |
-|    :align: center                           | * Open-source roots:                                  |
-|                                             |   `OpenStack Keystone <http://docs.openstack.org/     |
-| Rackspace Identity                          |   developer/keystone/>`__                             |
+| .. image::                                  | * :kc-article:`Product overview                       |
+|    /_images/logo-cloudidentity-50x50.png    |   <managing-role-based-access-control-rbac>`          |
+|    :alt: Rackspace Identity                 | * Free with every cloud account                       |
+|          manages authentication.            | * Open-source roots:                                  |
+|    :align: center                           | * :os-docs:`OpenStack Keystone <developer/keystone>`  |
+|                                             |                                                       |
+| Rackspace Identity                          |                                                       |
 | manages authentication.                     |                                                       |
 +---------------------------------------------+-------------------------------------------------------+
 
-Rackspace Identity is the authentication and 
-user-administration service. 
-With Rackspace Identity, you can manage role-based access 
+Rackspace Identity is the authentication and
+user-administration service.
+With Rackspace Identity, you can manage role-based access
 to other Rackspace services.

--- a/cloud-intro/context.rst
+++ b/cloud-intro/context.rst
@@ -12,25 +12,26 @@ Rackspace data centers. The flexibility of OpenStack backed by the
 support of Rackspace is a unique and powerful combination; as a user of
 our managed cloud, you can expect to benefit from that synergy.
 
-If someday you choose to work with an OpenStack cloud 
+If someday you choose to work with an OpenStack cloud
 but prefer not to do so
 within the Rackspace managed cloud, you can expect that transition to be
-easy. 
-When you are a Rackspace customer 
-operating in the Rackspace managed cloud, 
+easy.
+When you are a Rackspace customer
+operating in the Rackspace managed cloud,
 several alternatives are a short distance away:
 
-* You can use our `Managed Private
-  Cloud <http://www.rackspace.com/cloud/private>`__ product to create
+* You can use our :rax-cloud:`Managed Private Cloud <private>`
+  product to create
   and operate your own cloud on infrastructure managed by Rackspace.
 
 * You can install OpenStack yourself, on your own equipment, and manage
-  your own cloud with your own personnel on your own infrastructure. 
-  `DevStack <http://docs.openstack.org/developer/devstack/>`__ can 
-  help you quickly build your own OpenStack cloud, potentially 
-  `suitable for your internal software development <http://docs.openstack.org/developer/devstack/faq.html#can-i-use-devstack-for-production>`__. 
+  your own cloud with your own personnel on your own infrastructure.
+  :os-docs:`DevStack <developer/devstack>` can
+  help you quickly build your own OpenStack cloud, potentially
+  :os-docs:`suitable for your internal software development <developer/devstack/faq.html#can-i-use-devstack-for-production>`.
+
 
 * You can find another provider and use their OpenStack-compliant
-  public cloud. The 
-  `OpenStack Marketplace <https://www.openstack.org/marketplace/public-clouds/>`__ 
+  public cloud. The
+  :os:`OpenStack Marketplace <marketplace/public-clouds/>`
   can help you identify other OpenStack cloud providers.

--- a/cloud-intro/core-infrastructure.rst
+++ b/cloud-intro/core-infrastructure.rst
@@ -4,8 +4,8 @@
 Rackspace cloud core infrastructure at a glance
 -----------------------------------------------
 Your Rackspace cloud configuration is backed by the physical
-infrastructure in our 
-`data centers <http://www.rackspace.com/about/datacenters>`__.
+infrastructure in our
+:rax:`data centers <about/datacenters>`. 
 
 The virtual infrastructure of the managed cloud is provided by
 infrastructure-as-a-service (IaaS) software services that perform some
@@ -23,25 +23,25 @@ of the same functions as hardware devices in our data centers:
 
 * Additional services enable specific activities such as user
   authentication, load balancing, and event monitoring.
-  
+
 .. figure:: /_images/core-infrastructure.png
-   :alt: Cloud Servers, Cloud Networks, Cloud Images, 
+   :alt: Cloud Servers, Cloud Networks, Cloud Images,
          and Cloud Block Storage are the
-         Rackspace cloud's core infrastructure. 
-         From the Cloud Control Panel, 
-         you can send a request to the API for 
-         a cloud service. 
+         Rackspace cloud's core infrastructure.
+         From the Cloud Control Panel,
+         you can send a request to the API for
+         a cloud service.
          The service processes
          your request.*
-            
-   *Cloud Servers, Cloud Networks, Cloud Images, 
-   and Cloud Block Storage are the            
-   Rackspace cloud's core infrastructure.From the Cloud Control Panel, 
+
+   *Cloud Servers, Cloud Networks, Cloud Images,
+   and Cloud Block Storage are the
+   Rackspace cloud's core infrastructure.From the Cloud Control Panel,
    you can send a request to the API for a cloud service.
    The service processes
    your request.*
 
-.. :scale: is ignored here; resized the image directly 
+.. :scale: is ignored here; resized the image directly
    to 50% of its natural draw.io size
-   http://docs.readthedocs.org/en/latest/faq.html#image-scaling-doesn-t-work-in-my-documentation 
+   http://docs.readthedocs.org/en/latest/faq.html#image-scaling-doesn-t-work-in-my-documentation
    may explain why scaling doesn't work

--- a/cloud-intro/customer-stories.rst
+++ b/cloud-intro/customer-stories.rst
@@ -7,15 +7,15 @@ You have big ideas of your own, but thinking about what other customers
 have accomplished in the Rackspace cloud may give you some new
 inspiration. To learn about customers who have used the cloud to help them
 meet some of the same challenges you are facing, start at
-`rackStories: Rackspace customer culture <http://stories.rackspace.com/customers>`__. 
+`rackStories: Rackspace customer culture <http://stories.rackspace.com/customers>`__.
 
 Other good places to find
 customer stories include:
 
-* `Case studies and white papers in technical documentation <http://www.rackspace.com/knowledge_center/case-studies-white-papers>`__
+* :kc:`Case studies and white papers in technical documentation <case-studies-white-papers>`
 
-* `Postings in the "Partner & Customer Updates" channel of the Rackspace blog <http://www.rackspace.com/blog/channels/partner-and-customer-updates/>`__
+* :rax:`Postings in the "Partner & Customer Updates" channel of the Rackspace blog <blog/channels/partner-and-customer-updates>`
 
-* `Postings from Racker and customer developers in the Rackspace developer blog <https://developer.rackspace.com/blog/>`__
+* :rax-dev:`Postings from Racker and customer developers in the Rackspace developer blog <blog>`
 
 * `Discussions with Rackers and customers in the Rackspace Community <https://community.rackspace.com/>`__

--- a/conf.py
+++ b/conf.py
@@ -28,7 +28,11 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary']
+extensions = [
+     'sphinx.ext.autodoc',
+     'sphinx.ext.autosummary',
+     'sphinx.ext.extlinks'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -86,6 +90,23 @@ exclude_patterns = ['_build']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
+
+# External link library
+extlinks = {
+    'rax': ('http://www.rackspace.com/%s', ''),
+    'rax-cloud': ('http://www.rackspace.com/cloud/%s', ''),
+    'rax-docs': ('http://docs.rackspace.com/%s', ''),
+    'rax-dev': ('https://developer.rackspace.com/%s', ''),
+    'rax-api': ('http://api.rackspace.com/%s', ''),
+    'kc': ('http://www.rackspace.com/knowledge_center/%s', ''),
+    'kc-article': ('http://www.rackspace.com/knowledge_center/article/%s', ''),
+    'os': ('http://www.openstack.org/%s', ''),
+    'os-docs': ('http://docs.openstack.org/%s', ''),
+    'os-wiki': ('http://wiki.openstack.org/%s', ''),
+    'git-repo': ('https://github.com/rackerlabs/docs-core-infra-user-guide/%s', ''),
+    'rackerlabs': ('https://github.com/rackerlabs/%s', ''),
+    'rocket': ('https://objectrocket.com/%s', '')
+}
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []


### PR DESCRIPTION
Add sphinx.ext.extlinks to extensions in conf.py file along with list of extlinks. Trolled through Intro to the Guide and Cloud Intro to replace old link format with extlinks.