### PR TITLE
fixing cloud files pages for navigation

### DIFF
--- a/cloud-config/storage/cloud-files-product-concepts/ideal-uses.rst
+++ b/cloud-config/storage/cloud-files-product-concepts/ideal-uses.rst
@@ -1,0 +1,21 @@
+.. _ideal-uses:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ideal Uses for Cloud Files
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+The Cloud Files service is an excellent storage solution for a number
+of scenarios and is well suited to numerous applications.
+Following are some of the ideal uses for Cloud Files:
+
+* Backing up or archiving data
+* Serving images and videos (streaming data to users' browsers)
+* Serving content with a world-class CDN (Akamai)
+* Storing secondary, or tertiary, static, web-accessible data
+* Developing new applications with data storage integration
+* Storing data when predicting storage capacity is difficult
+* Storing data for applications affordably
+
+The Rackspace technical documentation provides many more details about
+Cloud Files. Begin exploring at
+:kc:`Cloud Files support <product-page/cloud-files>` and
+:kc:`Getting Started with Cloud Files <getting-started/cloud-files>`.

--- a/cloud-config/storage/cloud-files-product-concepts/index.rst
+++ b/cloud-config/storage/cloud-files-product-concepts/index.rst
@@ -29,25 +29,6 @@ RESTful API and make it easy for integration into your applications.
    mark the container as public, and begin serving that content
    from a powerful CDN.*
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-Ideal Uses for Cloud Files
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-The Cloud Files service is an excellent storage solution for a number
-of scenarios and is well suited to numerous applications.
-Following are some of the ideal uses for Cloud Files:
-
-* Backing up or archiving data
-* Serving images and videos (streaming data to users' browsers)
-* Serving content with a world-class CDN (Akamai)
-* Storing secondary, or tertiary, static, web-accessible data
-* Developing new applications with data storage integration
-* Storing data when predicting storage capacity is difficult
-* Storing data for applications affordably
-
-The Rackspace technical documentation provides many more details about
-Cloud Files. Begin exploring at
-:kc:`Cloud Files support <product-page/cloud-files>` and
-:kc:`Getting Started with Cloud Files <getting-started/cloud-files>`.
 
 
 
@@ -55,6 +36,7 @@ Cloud Files. Begin exploring at
 .. toctree:: :hidden:
    :maxdepth: 2
 
+   ideal-uses
    object-storage
    web-acceleration
    tools


### PR DESCRIPTION
pulled "Ideal Uses for Cloud Files" out of index.rst and made a new page for it. This should hopefully fix the navigation issues I've been having.