### PR TITLE
added backup information to cinder page

### DIFF
--- a/cloud-config/storage/cloud-files-product-concepts/web-acceleration.rst
+++ b/cloud-config/storage/cloud-files-product-concepts/web-acceleration.rst
@@ -66,6 +66,7 @@ browser. For example, a pathed object named ducks/funny/duckling.jpg
 would become
 
 .. code::
+
    http://c123456.r02.cf3.rackcdn.com/ducs/funny/duckling.jpg
 
 .. TIP::

--- a/cloud-interfaces/cli/cinder.rst
+++ b/cloud-interfaces/cli/cinder.rst
@@ -20,4 +20,9 @@ and learn to use it:
 
 * :os-docs:`cinder CLI man page <developer/python-cinderclient/man/cinder.html>`
 
+You can use cinder to back up your volumes to :ref:`swift`, the OpenStack tool
+used to interact with Cloud Files. For more information about how to back up
+your cinder volumes, see
+:rax-dev:`Backing Up cinder Volumes to swift <blog/backing-up-cinder-volumes-to-swift/>`.
+
 .. include:: /_common/note-openstack-username.txt

--- a/cloud-interfaces/gui/cloudfiles-gui.rst
+++ b/cloud-interfaces/gui/cloudfiles-gui.rst
@@ -14,7 +14,7 @@ under **Storage**.
    :scale: 80%
    :alt: The Storage group includes Cloud Files.
 
-   *The Storage group includes Cloud Files.
+   *The Storage group includes Cloud Files.*
 
 You can use the Cloud Control Panel to help you
 observe and manage your Cloud Block Storage configuration.


### PR DESCRIPTION
found a blog post on developer that talks about backing up cinder volumes to swift, and included a link to it in the cinder page