### PR TITLE
Updated extlink library to add path for product-FAQs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -103,6 +103,7 @@ extlinks = {
     'kc': ('http://www.rackspace.com/knowledge_center/%s', ''),
     'kc-article': ('http://www.rackspace.com/knowledge_center/article/%s', ''),
     'kc-faq': ('http://www.rackspace.com/knowledge_center/frequently-asked-question/%s', ''),
+    'kc-product-faq': ('http://www.rackspace.com/knowledge_center/product-faq/%s', ''),
     'os': ('http://www.openstack.org/%s', ''),
     'os-docs': ('http://docs.openstack.org/%s', ''),
     'os-wiki': ('http://wiki.openstack.org/%s', ''),


### PR DESCRIPTION
We have two common paths for KC FAQs: frequently-asked-questions
and product-FAQ.  Added a link shortcut for the product-FAQ.