### PR TITLE
Fix how to links

### DIFF
--- a/_common/note-rbac-actions.txt
+++ b/_common/note-rbac-actions.txt
@@ -10,4 +10,4 @@
    the specific permissions granted to the ID you use.
 
    You can learn more about RBAC at
-   :how-to:`Getting Started with Role-Based Access Control (RBAC) <getting-started-with-role-based-access-control-rbac>`.
+   :how-to:`Getting Started with Role-Based Access Control (RBAC) <getting-started-with-role-based-access-control-rbac/>`.

--- a/cloud-config/compute/cloud-images-product-concepts/import-export-images.rst
+++ b/cloud-config/compute/cloud-images-product-concepts/import-export-images.rst
@@ -19,7 +19,7 @@ open in the following ways:
   hardware.
 
 You can find more information about image importing and exporting in the
-:how-to:`Cloud Images FAQ <cloud-images-faq>`.
+:how-to:`Cloud Images FAQ <cloud-images-faq/>`.
 
 Exporting an image
 ''''''''''''''''''

--- a/cloud-config/compute/cloud-images-product-concepts/on-demand-images.rst
+++ b/cloud-config/compute/cloud-images-product-concepts/on-demand-images.rst
@@ -18,7 +18,7 @@ correctly when you boot a server from the image. The time that such
 applications should be quiesced is fairly brief and can be monitored by
 observing your Cloud Server's task state.
 For more information, see
-:how-to:`Using Task States with Server Imaging <using-task-states-with-server-imaging>`
+:how-to:`Using Task States with Server Imaging <using-task-states-with-server-imaging/>`
 in  Rackspace How-To.
 
 .. include:: /_common/seealso-concepts-cloud-images.txt

--- a/cloud-config/compute/cloud-images-product-concepts/scheduled-images.rst
+++ b/cloud-config/compute/cloud-images-product-concepts/scheduled-images.rst
@@ -10,6 +10,6 @@ image of the server. Remember that a virtual machine image is not really
 a backup of a server, so whether scheduled images are an appropriate
 solution for you depends on your use case.
 For more information, see the
-:how-to:`Scheduled Images FAQ <scheduled-images-faq>` in Rackspace How-To.
+:how-to:`Scheduled Images FAQ <scheduled-images-faq/>` in Rackspace How-To.
 
 .. include:: /_common/seealso-concepts-cloud-images.txt

--- a/cloud-config/compute/cloud-images-product-concepts/sharing-images/planning.rst
+++ b/cloud-config/compute/cloud-images-product-concepts/sharing-images/planning.rst
@@ -56,7 +56,7 @@ the same Rackspace cloud region as the producer.
 If you need to use the same image in multiple regions,
 you can create a copy of the image in each region.
 
-:how-to:`Transferring images between regions of the Rackspace open cloud <transferring-images-between-regions-of-the-rackspace-open-cloud>`
+:how-to:`Transferring images between regions of the Rackspace open cloud <transferring-images-between-regions-of-the-rackspace-open-cloud/>`
 demonstrates a method of placing an image within a Cloud Files
 container in one region and then retrieving it from the container
 in another region. This is a complex, multi-step method but it might be

--- a/cloud-config/compute/cloud-servers-product-actions/index.rst
+++ b/cloud-config/compute/cloud-servers-product-actions/index.rst
@@ -31,7 +31,7 @@ All data and disk formatting is lost.
       :columns: 3
 
       * :how-to:`Cloud Control Panel
-        <rebuild-a-cloud-server>`
+        <rebuild-a-cloud-server/>`
       * :rax-dev-docs:`Rack CLI
         <rack-cli/services/servers/#rebuild>`
       * :rax-dev-docs:`Rackspace Cloud Servers API
@@ -63,7 +63,7 @@ After 24 hours, your resize is automatically confirmed.
       :columns: 3
 
       * :how-to:`Cloud Control Panel
-        <managing-your-server-resizing-standard-and-general-purpose-servers>`
+        <managing-your-server-resizing-standard-and-general-purpose-servers/>`
       * :rax-dev-docs:`Rack CLI
         <rack-cli/services/servers/#resize>`
       * :rax-dev-docs:`Rackspace Cloud Servers API
@@ -94,7 +94,7 @@ with any changes made. Rescue mode is automatically exited after 24 hours.
         :columns: 3
 
         * :how-to:`Cloud Control Panel
-          <rescue-mode>`
+          <rescue-mode/>`
         * *Rack CLI not available*
         * :rax-dev-docs:`Rackspace Cloud Servers API
           <cloud-servers/v2/developer-guide/#rescue-specified-server>`
@@ -113,7 +113,7 @@ shutdown and restart.
       :columns: 3
 
       * :how-to:`Cloud Control Panel
-        <reboot-your-server>`
+        <reboot-your-server/>`
       * :rax-dev-docs:`Rack CLI
         <rack-cli/services/servers/#reboot>`
       * :rax-dev-docs:`Rackspace Cloud Servers API
@@ -138,7 +138,7 @@ the primary method of access.
       :columns: 3
 
       * :how-to:`Cloud Control Panel
-        <start-a-console-session>`
+        <start-a-console-session/>`
       * *Rack CLI not available*
       * :rax-dev-docs:`Rackspace Cloud Servers API
         <cloud-servers/v2/developer-guide/#post-get-console-servers-server-id-action>`
@@ -156,7 +156,7 @@ from the disk of a deleted server.
       :columns: 3
 
       * :how-to:`Cloud Control Panel
-        <deleting-your-server>`
+        <deleting-your-server/>`
       * :rax-dev-docs:`Rack CLI
         <rack-cli/services/servers/#delete>`
       * :rax-dev-docs:`Rackspace Cloud Servers API

--- a/cloud-config/compute/cloud-servers-product-concepts/flavor-class/check-region-flavor-class.rst
+++ b/cloud-config/compute/cloud-servers-product-concepts/flavor-class/check-region-flavor-class.rst
@@ -29,7 +29,7 @@ Other configuration options you can choose for that cloud server
 Considerations other than the availability of a flavor class can
 influence your choice of the optimal region
 in which to create a new cloud server.
-:how-to:`About regions <about-regions>`
+:how-to:`About regions <about-regions/>`
 discusses some of the other factors
 you should consider.
 

--- a/cloud-config/compute/cloud-servers-product-concepts/server-region.rst
+++ b/cloud-config/compute/cloud-servers-product-concepts/server-region.rst
@@ -11,7 +11,7 @@ you might want it to be hosted in our SYD (Sydney) region rather than
 in our DFW (Dallas-Fort Worth) region.
 
 For more information on regions, begin with the How-To article,
-:how-to:`About regions <about-regions>`.
+:how-to:`About regions <about-regions/>`.
 
 Beyond a general preference for a region, working in the cloud
 means that you need not be concerned with selecting among the hundreds

--- a/cloud-config/network/cloud-networks-product-concepts/dns.rst
+++ b/cloud-config/network/cloud-networks-product-concepts/dns.rst
@@ -35,7 +35,7 @@ select **Networking > Cloud DNS > Create Domain**:
 For more information about using the Cloud Control Panel to
 manage DNS information,
 read
-:how-to:`Create DNS Records for cloud servers with the Control Panel <create-dns-records-for-cloud-servers-with-the-control-panel>`.
+:how-to:`Create DNS Records for cloud servers with the Control Panel <create-dns-records-for-cloud-servers-with-the-control-panel/>`.
 
 You can also use the Cloud DNS API to manage DNS information
 programmatically. Begin reading about that in the

--- a/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
+++ b/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
@@ -28,7 +28,7 @@ Cloud Networks API documentation under
 :rax-dev-devguide:`Security groups operations <cloud-networks/v2/developer-guide/#document-api-operations/sec-group-operations>`.
 
 To learn more about security groups, read
-:how-to:`Security groups FAQ <cloud-networks-faq>` and
+:how-to:`Security groups FAQ <cloud-networks-faq/>` and
 :rax-docs:`Use security groups to control traffic <networks/api/v2/cn-gettingstarted/content/security_groups.html>`.
 
 .. include:: /_common/seealso-concepts-cloud-networks.txt

--- a/cloud-config/storage/cloud-block-storage-product-concepts/backup-methods.rst
+++ b/cloud-config/storage/cloud-block-storage-product-concepts/backup-methods.rst
@@ -39,7 +39,7 @@ created a backup copy of your data, you can restore all your
 folders and files from the backup, you can restore individual files
 or folders from a given date, or you can restore to an entirely different
 server. For more information about Cloud Backup, begin at
-:how-to:`Rackspace Cloud Backup - Overview <rackspace-cloud-backup-overview>`.
+:how-to:`Rackspace Cloud Backup - Overview <rackspace-cloud-backup-overview/>`.
 
 Backup method: Cloud Block Storage
 ''''''''''''''''''''''''''''''''''

--- a/cloud-config/storage/cloud-block-storage-product-concepts/block-storage.rst
+++ b/cloud-config/storage/cloud-block-storage-product-concepts/block-storage.rst
@@ -28,6 +28,6 @@ particularly useful for OnMetal Compute and Memory v1 flavors.
 
 To learn how to attach a volume to your OnMetal server, begin
 with
-:how-to:`Attach a Cloud Block Storage Volume to an OnMetal server <attach-a-cloud-block-storage-volume-to-an-onmetal-server>`.
+:how-to:`Attach a Cloud Block Storage Volume to an OnMetal server <attach-a-cloud-block-storage-volume-to-an-onmetal-server/>`.
 
 .. include:: /_common/seealso-concepts-cloud-block-storage.txt

--- a/cloud-config/storage/cloud-block-storage-product-concepts/disk-storage.rst
+++ b/cloud-config/storage/cloud-block-storage-product-concepts/disk-storage.rst
@@ -54,11 +54,11 @@ appropriate for that server's operating system:
 
 * For Linux,
   see
-  :how-to:`Preparing Data Disks on Linux Cloud Servers <preparing-data-disks-on-linux-cloud-servers>`.
+  :how-to:`Preparing Data Disks on Linux Cloud Servers <preparing-data-disks-on-linux-cloud-servers/>`.
 
 * For Windows,
   see
-  :how-to:`Preparing Data Disks on Windows Cloud Servers <preparing-data-disks-on-windows-cloud-servers>`.
+  :how-to:`Preparing Data Disks on Windows Cloud Servers <preparing-data-disks-on-windows-cloud-servers/>`.
 
 .. TIP::
    To make a backup copy of a *data* disk, use one of the following services:

--- a/cloud-config/storage/cloud-block-storage-product-concepts/index.rst
+++ b/cloud-config/storage/cloud-block-storage-product-concepts/index.rst
@@ -37,12 +37,12 @@ staging of common server images in Cloud Block Storage.
 .. TIP::
    For instructions on using the Cloud Block Storage boot-from-volume feature,
    see
-   :how-to:`Boot a server from a Cloud Block Storage volume <boot-a-server-from-a-cloud-block-storage-volume>`.
+   :how-to:`Boot a server from a Cloud Block Storage volume <boot-a-server-from-a-cloud-block-storage-volume/>`.
 
 The Rackspace technical documentation provides many more details about Cloud
 Block Storage. Begin exploring
 at
-:how-to:`Cloud Block Storage support <cloud-block-storage>`.
+:how-to:`Cloud Block Storage support <cloud-block-storage/>`.
 
 ..
 .. below, the include provides visible links

--- a/cloud-config/storage/cloud-block-storage-product-concepts/local-storage.rst
+++ b/cloud-config/storage/cloud-block-storage-product-concepts/local-storage.rst
@@ -58,7 +58,7 @@ In that experiment,
 Cloud Block Storage on SSD performed
 better than any other option tested.
 In a white paper on
-:how-to:`Cloud Block Storage (CBS) Benchmarking <white-paper/cloud-block-storage-cbs-benchmarking>`,
+`Cloud Block Storage (CBS) Benchmarking <https://support.rackspace.com/white-paper/cloud-block-storage-cbs-benchmarking/>`__,
 performance quadrupled using Cloud Block Storage with SSD
 as compared to Cloud Block Storage with SATA.
 
@@ -131,8 +131,8 @@ For more information about OnMetal, see the following resources:
 
 * :rax:`OnMetal: The Right Way To Scale <blog/onmetal-the-right-way-to-scale/>`
 
-* :how-to:`What is new with OnMetal Cloud Servers <what-is-new-with-onmetal-cloud-servers>`
+* :how-to:`What is new with OnMetal Cloud Servers <what-is-new-with-onmetal-cloud-servers/>`
 
-* :how-to:`Create OnMetal Cloud Servers <create-onmetal-cloud-servers>`
+* :how-to:`Create OnMetal Cloud Servers <create-onmetal-cloud-servers/>`
 
 .. include:: /_common/seealso-concepts-cloud-block-storage.txt

--- a/cloud-config/storage/cloud-block-storage-product-concepts/software-raid.rst
+++ b/cloud-config/storage/cloud-block-storage-product-concepts/software-raid.rst
@@ -44,7 +44,7 @@ Software RAID for Linux
 '''''''''''''''''''''''
 To learn how to set up software RAID on a cloud server running Linux,
 read
-:how-to:`Configuring a Software RAID on a Linux General Purpose Cloud Server <configuring-a-software-raid-on-a-linux-general-purpose-cloud-server>`.
+:how-to:`Configuring a Software RAID on a Linux General Purpose Cloud Server <configuring-a-software-raid-on-a-linux-general-purpose-cloud-server/>`.
 
 Software RAID for Windows
 '''''''''''''''''''''''''

--- a/cloud-config/storage/cloud-files-product-concepts/ideal-uses.rst
+++ b/cloud-config/storage/cloud-files-product-concepts/ideal-uses.rst
@@ -17,6 +17,6 @@ Following are some of the ideal uses for Cloud Files:
 
 The Rackspace technical documentation provides many more details about
 Cloud Files. Begin exploring at the
-:how-to:`Cloud Files introduction <cloud-files>` page.
+:how-to:`Cloud Files introduction <cloud-files/>` page.
 
 .. include:: /_common/seealso-concepts-cloud-files.txt

--- a/cloud-config/storage/cloud-files-product-concepts/tools.rst
+++ b/cloud-config/storage/cloud-files-product-concepts/tools.rst
@@ -15,7 +15,7 @@ your Cloud Files. Following are a few of the available options:
 * **Cyberduck** is a full-featured browser to publish your content
   on Cloud Files and manage your CDN distributions. `Download Cyberduck
   <http://cyberduck.ch/>`__ and get started at
-  :how-to:`Configuring Rackspace Cloud Files with Cyberduck <configuring-rackspace-files-with-cyberduck>`.
+  :how-to:`Configuring Rackspace Cloud Files with Cyberduck <configuring-rackspace-files-with-cyberduck/>`.
 * **Django-Cloudfiles** is an extension to the management system
   of the website framework, Django. Django-Cloudfiles enables you
   to synchronize the static content delivery of your

--- a/cloud-config/storage/cloud-files-product-concepts/web-acceleration.rst
+++ b/cloud-config/storage/cloud-files-product-concepts/web-acceleration.rst
@@ -82,6 +82,6 @@ would become
    You can use CNAME records to link your Cloud Files container to a
    branded URL that you display instead of a CDN URL. To learn more about
    CNAMEs, check out
-   :how-to:`Using CNAMEs with Cloud Files containers <using-cnames-with-cloud-files-containers>`.
+   :how-to:`Using CNAMEs with Cloud Files containers <using-cnames-with-cloud-files-containers/>`.
 
 .. include:: /_common/seealso-concepts-cloud-files.txt

--- a/cloud-interfaces/api/setup-api.rst
+++ b/cloud-interfaces/api/setup-api.rst
@@ -10,7 +10,7 @@ The basic process is the same for all Rackspace APIs:
 
 1. Collect the parts that you need for the request:
 
-   * Obtain your account credentials (:how-to:`API key <view-and-reset-your-api-key>` and account number, also called tenant ID) from the `Cloud Control Panel <https://mycloud.rackspace.com/>`__.
+   * Obtain your account credentials (:how-to:`API key <view-and-reset-your-api-key/>` and account number, also called tenant ID) from the `Cloud Control Panel <https://mycloud.rackspace.com/>`__.
    * :rax-dev-devguide:`Use your credentials to authenticate <cloud-identity/v2/developer-guide/#document-quickstart-guide>`, receiving a token and a service catalog as proof of success
    * In the :rax-dev-devguide:`service catalog <cloud-identity/v2/developer-guide/#annotated-authentication-request-and-response>`, find the endpoint for the API to which you want to send a request.
    * Look up the :rax-api:`syntax of the API request <>`.

--- a/cloud-interfaces/cli/cloudblockstorage-cli.rst
+++ b/cloud-interfaces/cli/cloudblockstorage-cli.rst
@@ -31,7 +31,7 @@ In working with Cloud Block Storage,
 you might find that you need to use nova for some functions
 and cinder for others. You should install them both.
 You can see an example of using nova and cinder together at
-:how-to:`Configuring OpenStack Block Storage <configuring-openstack-block-storage>`
+:how-to:`Configuring OpenStack Block Storage <configuring-openstack-block-storage/>`
 where, in the "Create a Volume" section,
 ``nova volume-attach`` associates a volume with a server
 and ``cinder list`` confirms that association.

--- a/cloud-interfaces/cli/curl.rst
+++ b/cloud-interfaces/cli/curl.rst
@@ -17,7 +17,7 @@ The following Rackspace publications provide basic information
 about cURL:
 
 * :rax-docs:`How cURL commands work <servers/api/v2/cn-gettingstarted/content/curl.html>`
-* :how-to:`Cloud Files cURL Cookbook <cloud-files-curl-cookbook>`
+* :how-to:`Cloud Files cURL Cookbook <cloud-files-curl-cookbook/>`
 * :rax-docs:`Authenticate with cURL <servers/api/v2/cs-gettingstarted/content/curl_auth.html>`
 
 In the

--- a/cloud-interfaces/cli/nova.rst
+++ b/cloud-interfaces/cli/nova.rst
@@ -46,7 +46,7 @@ on most popular operating systems:
 * In the Cloud Servers API documentation at
   :rax-docs:`Install the nova Client with the Cloud Networks Extension <servers/api/v2/cs-gettingstarted/content/section_gs_install_nova.html>`
 * In
-  :how-to:`Python-novaclient and the Rackspace Cloud <using-python-novaclient-with-the-rackspace-cloud>`
+  :how-to:`Python-novaclient and the Rackspace Cloud <using-python-novaclient-with-the-rackspace-cloud/>`
 
 After you have novaclient installed, you must set up your
 environment so that you can authenticate to Rackspace and use the

--- a/cloud-interfaces/cli/swiftly.rst
+++ b/cloud-interfaces/cli/swiftly.rst
@@ -10,7 +10,7 @@ image file), swiftly will take care of splitting the file into
 smaller "segments" and then creating the large object
 "manifest" for you.
 
-:how-to:`Install the Swiftly Client for Cloud Files <install-the-swiftly-client-for-cloud-files>`
+:how-to:`Install the Swiftly Client for Cloud Files <install-the-swiftly-client-for-cloud-files/>`
 walks through the installation process for swiftly.
 
 The following resources can help you install and use

--- a/cloud-interfaces/gui/cloudblockstorage-gui.rst
+++ b/cloud-interfaces/gui/cloudblockstorage-gui.rst
@@ -20,4 +20,4 @@ You can use the Cloud Control Panel to help you
 observe and manage your Cloud Block Storage configuration.
 For ideas about what to do first,
 visit the
-:how-to:`Cloud Block Storage introduction page <cloud-block-storage>`.
+:how-to:`Cloud Block Storage introduction page <cloud-block-storage/>`.

--- a/cloud-interfaces/gui/cloudfiles-gui.rst
+++ b/cloud-interfaces/gui/cloudfiles-gui.rst
@@ -20,7 +20,7 @@ You can use the Cloud Control Panel to help you
 observe and manage your Cloud Files configuration.
 For ideas about what to do first,
 visit
-:how-to:`Cloud Files overview <cloud-files-overview>`.
+:how-to:`Cloud Files overview <cloud-files-overview/>`.
 
 Create a Container
 ''''''''''''''''''
@@ -47,7 +47,7 @@ In the top navigation bar, select **Storage > Files** and click
   by going to your domain hose and setting up a CNAME to your CDN URL.
   For more information on hosting static websites, try
   :how-to:`Serve Static Content for Websites by Using Cloud Files
-  <serve-static-content-for-websites-by-using-cloud-files>`.
+  <serve-static-content-for-websites-by-using-cloud-files/>`.
 
 Upload Files to the Container
 '''''''''''''''''''''''''''''

--- a/cloud-interfaces/gui/cloudimages-gui.rst
+++ b/cloud-interfaces/gui/cloudimages-gui.rst
@@ -21,4 +21,4 @@ You can use the Cloud Control Panel to help you
 observe and manage your Cloud Images configuration.
 For ideas about what to do first,
 visit the
-:how-to:`Rackspace Cloud Images introduction page <cloud-images>`.
+:how-to:`Rackspace Cloud Images introduction page <cloud-images/>`.

--- a/cloud-interfaces/gui/cloudnetworks-gui.rst
+++ b/cloud-interfaces/gui/cloudnetworks-gui.rst
@@ -20,4 +20,4 @@ You can use the Cloud Control Panel to help you
 observe and manage your Cloud Networks configuration.
 For ideas about what to do first,
 visit the
-:how-to:`Cloud Networks introduction page <cloud-networks>`.
+:how-to:`Cloud Networks introduction page <cloud-networks/>`.

--- a/cloud-interfaces/gui/cloudservers-gui.rst
+++ b/cloud-interfaces/gui/cloudservers-gui.rst
@@ -22,4 +22,4 @@ You can use the Cloud Control Panel to help you
 observe and manage your Cloud Servers configuration.
 For ideas about what to do first,
 visit the
-:how-to:`Rackspace Cloud Servers introduction page <cloud-servers>`.
+:how-to:`Rackspace Cloud Servers introduction page <cloud-servers/>`.

--- a/cloud-interfaces/gui/index.rst
+++ b/cloud-interfaces/gui/index.rst
@@ -16,16 +16,16 @@ your Rackspace account.
 You can also use the Cloud Control Panel to complete some important
 first tasks:
 
-* :how-to:`Obtain your API key <view-and-reset-your-api-key>`
+* :how-to:`Obtain your API key <view-and-reset-your-api-key/>`
   for use with
   :ref:`CLIs <cloud-interfaces-cli>`,
   :ref:`SDKs <sdk>`,
   and
   :ref:`APIs <direct-api-access>`
 
-* :how-to:`Create additional account users <managing-role-based-access-control-rbac>`
+* :how-to:`Create additional account users <managing-role-based-access-control-rbac/>`
   and give them
-  :how-to:`permissions <permissions-matrix-for-role-based-access-control-rbac>`
+  :how-to:`permissions <permissions-matrix-for-role-based-access-control-rbac/>`
   if needed
 
   .. note::

--- a/cloud-intro/cloud-tour/application-services.rst
+++ b/cloud-intro/cloud-tour/application-services.rst
@@ -15,7 +15,7 @@ Auto Scale at a glance
 ~~~~~~~~~~~~~~~~~~~~~~
 +------------------------------------------------+------------------------------------------------+
 |                                                |                                                |
-| .. image::                                     | * :rax-cloud:`Product overview <auto-scale>`   |
+| .. image::                                     | * :rax-cloud:`Product overview <auto-scale/>`  |
 |    /_images/logo-autoscale-50x50.png           | * Free with every cloud account                |
 |    :alt: Auto Scale meets                      | * Open-source roots:                           |
 |          user demand.                          |   :rackerlabs:`Otter <otter>`                  |
@@ -29,7 +29,7 @@ Rackspace Metrics at a glance
 +------------------------------------------------+------------------------------------------------+
 |                                                |                                                |
 | .. image::                                     | * :how-to:`Product overview                    |
-|    /_images/logo-cloudmetrics-50x50.png        |   <rackspace-metrics>`                         |
+|    /_images/logo-cloudmetrics-50x50.png        |   <rackspace-metrics/>`                        |
 |    :alt: Rackspace Metrics stores and serves   | * Free with every cloud account                |
 |          time-series metrics.                  | * Open-source roots:                           |
 |    :align: center                              |   `Blueflood <http://blueflood.io/>`__         |
@@ -42,7 +42,7 @@ Cloud Monitoring at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 +------------------------------------------------+------------------------------------------------+
 |                                                |                                                |
-| .. image::                                     | * :rax-cloud:`Product overview <monitoring>`   |
+| .. image::                                     | * :rax-cloud:`Product overview <monitoring/>`  |
 |    /_images/logo-cloudmonitoring-50x50.png     | * Free with every cloud account                |
 |    :alt: Cloud Monitoring monitors             | * Open-source roots:                           |
 |          the infrastructure.                   |   `Virgo                                       |
@@ -56,7 +56,7 @@ Cloud Orchestration at a glance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 +------------------------------------------------+-------------------------------------------------+
 |                                                |                                                 |
-| .. image::                                     | * :rax-cloud:`Product overview <orchestration>` |
+| .. image::                                     | * :rax-cloud:`Product overview <orchestration/>`|
 |    /_images/logo-cloudorchestration-50x50.png  | * Free with every cloud account                 |
 |    :alt: Cloud Orchestration automates         | * Open-source roots:                            |
 |          and standardizes infrastructure.      |   :os-docs:`OpenStack Heat <developer/heat>`    |
@@ -71,7 +71,7 @@ Rackspace Intelligence
 +-----------------------------------------------------+---------------------------------------------+
 |                                                     |                                             |
 | .. image::                                          | * :how-to:`Product overview                 |
-|    /_images/logo-rackspaceintelligence-50x50.png    |   <rackspace-intelligence>`                 |
+|    /_images/logo-rackspaceintelligence-50x50.png    |   <rackspace-intelligence/>`                |
 |    :alt: Rackspace Intelligence provides a          | * Free with every cloud account             |
 |          transparent view of infrastructure health. |                                             |
 |    :align: center                                   |                                             |

--- a/cloud-intro/cloud-tour/support-services.rst
+++ b/cloud-intro/cloud-tour/support-services.rst
@@ -13,7 +13,7 @@ Cloud Feeds at a glance
 +---------------------------------------------+-------------------------------------------------------+
 |                                             |                                                       |
 | .. image::                                  | * :how-to:`Product overview                           |
-|    /_images/logo-cloudfeeds-50x50.png       |   <cloud-feeds-overview>`                             |
+|    /_images/logo-cloudfeeds-50x50.png       |   <cloud-feeds-overview/>`                            |
 |    :alt: Cloud Feeds streamlines            | * Free with every cloud account                       |
 |          event notifications.               | * Open-source roots:                                  |
 |    :align: center                           |   `Atom Hopper <http://atomhopper.org/>`__            |
@@ -33,7 +33,7 @@ Rackspace Identity at a glance
 +---------------------------------------------+-------------------------------------------------------+
 |                                             |                                                       |
 | .. image::                                  | * :how-to:`Product overview                           |
-|    /_images/logo-cloudidentity-50x50.png    |   <managing-role-based-access-control-rbac>`          |
+|    /_images/logo-cloudidentity-50x50.png    |   <managing-role-based-access-control-rbac/>`         |
 |    :alt: Rackspace Identity                 | * Free with every cloud account                       |
 |          manages authentication.            | * Open-source roots:                                  |
 |    :align: center                           |   :os-docs:`OpenStack Keystone <developer/keystone>`  |

--- a/cloud-ops/bestpractice.rst
+++ b/cloud-ops/bestpractice.rst
@@ -23,11 +23,11 @@ remember these best practices:
 * Deploy a load balancer to allow you to more easily scale and
   update your application.
   Follow the configuration guidelines at
-  :how-to:`Configure a Load Balancer <configure-a-load-balancer>`.
+  :how-to:`Configure a Load Balancer <configure-a-load-balancer/>`.
 
 * Deploy backup and/or monitoring for your most important servers.
   Configure Cloud Backup as discussed at
-  :how-to:`Rackspace Cloud Backup overview <rackspace-cloud-backup-overview>`.
+  :how-to:`Rackspace Cloud Backup overview <rackspace-cloud-backup-overview/>`.
 
 Other best practices relate to specific services, options,
 and configurations:
@@ -57,19 +57,19 @@ Best practices for security
 
 *  Use SSH keys rather than passwords for Linux.
    Follow the procedure at
-   :how-to:`Basic Cloud Server Security <basic-cloud-server-security>`.
+   :how-to:`Basic Cloud Server Security <basic-cloud-server-security/>`.
 
 Best practices for storage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Use attached storage whenever possible because it will allow you to
   resize, backup, and plan for failure more gracefully.
   Follow the tutorial at
-  :how-to:`Create and Attach a Cloud Block Storage Volume <create-and-attach-a-cloud-block-storage-volume>`.
+  :how-to:`Create and Attach a Cloud Block Storage Volume <create-and-attach-a-cloud-block-storage-volume/>`.
 
 Best practices for networking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 *  Use
-   :how-to:`ServiceNet <cloud-load-balancers-faq>`
+   :how-to:`ServiceNet <cloud-load-balancers-faq/>`
    to communicate between Cloud Servers and Cloud Files and Cloud Databases.
    Use Cloud
    Networks for server-to-server communication.

--- a/cloud-ops/index.rst
+++ b/cloud-ops/index.rst
@@ -18,7 +18,7 @@ change your billing options, and to explore new services and features.
 
 To learn about some of the basic activities that you might
 need to perform in the Cloud Control Panel, begin with the
-:how-to:`Cloud Servers introduction page <cloud-servers>`.
+:how-to:`Cloud Servers introduction page <cloud-servers/>`.
 
 In the Rackspace cloud,
 you can quickly try something, decide that it isn't quite right for you,

--- a/cloud-ops/limits.rst
+++ b/cloud-ops/limits.rst
@@ -41,14 +41,14 @@ your account itself in several areas:
 Managing role-based access to services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Using role-based access control
-(:how-to:`RBAC <overview-role-based-access-control-rbac>`),
+(:how-to:`RBAC <overview-role-based-access-control-rbac/>`),
 you can divide responsibilities among members of your team. For
 example, you can enable a database administrator to schedule database
 backups and enable a network administrator to expand a load balancing
 group. The roles that make sense for your team are likely to change as
 your workload grows, your team grows, and you add more services to your
 configuration. You can see suggested role configurations at
-:how-to:`Managing: Role-Based Access Control (RBAC) <managing-role-based-access-control-rbac>`.
+:how-to:`Managing: Role-Based Access Control (RBAC) <managing-role-based-access-control-rbac/>`.
 
 Managing expenses by limiting workload
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/cloud-ops/troubleshoot.rst
+++ b/cloud-ops/troubleshoot.rst
@@ -20,9 +20,9 @@ apply to the Rackspace cloud as well:
 Rackspace provides tools to help you automate detection of and response to
 unusual situations such as workload spikes:
 
-* :how-to:`Rackspace Monitoring <cloud-monitoring>`
-* :how-to:`Rackspace Auto Scale <rackspace-auto-scale>`
-* :how-to:`Rackspace Intelligence <rackspace-intelligence>`
+* :how-to:`Rackspace Monitoring <cloud-monitoring/>`
+* :how-to:`Rackspace Auto Scale <rackspace-auto-scale/>`
+* :how-to:`Rackspace Intelligence <rackspace-intelligence/>`
 
 Rackspace provides a
 `real-time system status view <https://status.rackspace.com>`__
@@ -118,9 +118,9 @@ to enable cloud services to interact.
    To learn more about troubleshooting or preventing connectivity issues,
    read these articles:
 
-   * :how-to:`Basic network troubleshooting <basic-network-troubleshooting>`
+   * :how-to:`Basic network troubleshooting <basic-network-troubleshooting/>`
 
-   * :how-to:`Troubleshooting DNS issues <troubleshooting-dns-issues>`
+   * :how-to:`Troubleshooting DNS issues <troubleshooting-dns-issues/>`
 
    * :ref:`network-ssh`
 
@@ -223,7 +223,7 @@ also provides links to help you submit support tickets.
    To learn more about troubleshooting or preventing server build issues,
    read these articles:
 
-   * :how-to:`RackConnect power users guide <rackconnect-power-users-guide>`
+   * :how-to:`RackConnect power users guide <rackconnect-power-users-guide/>`
      suggests using the Cloud Servers API to build multiple servers in bursts
      rather than singly.
 

--- a/cloud-preprod/backups.rst
+++ b/cloud-preprod/backups.rst
@@ -18,4 +18,4 @@ time.
    moveable from one server to another.
 
 For advice regarding when to use Cloud Backup and Cloud Block Storage, see
-:how-to:`Best Practices for Backing Up Your Data: Cloud Block Storage versus Cloud Backup <best-practices-for-backing-up-your-data-cloud-block-storage-versus-cloud-backup>`.
+:how-to:`Best Practices for Backing Up Your Data: Cloud Block Storage versus Cloud Backup <best-practices-for-backing-up-your-data-cloud-block-storage-versus-cloud-backup/>`.

--- a/cloud-preprod/network-ssh.rst
+++ b/cloud-preprod/network-ssh.rst
@@ -5,7 +5,7 @@ Validating SSH configuration
 ----------------------------
 Depending on your circumstances, it may be appropriate for you to change the
 assignment of port 22 in your configuration. By default, port 22 is assigned to
-:how-to:`Secure Shell (SSH) <connecting-to-a-server-using-ssh-on-linux-or-mac-os>`.
+:how-to:`Secure Shell (SSH) <connecting-to-a-server-using-ssh-on-linux-or-mac-os/>`.
 Changing this assignment can make it harder for attackers to
 guess the location your SSH port, but that change can also make it impossible for some
 cloud services to coordinate their activities.
@@ -52,7 +52,7 @@ make sure you can answer the following questions:
   If **RackConnect Status** is **Deployed** for at least one server,
   then RackConnect is in use at your account.
   You can read more about this at
-  :how-to:`Accessing RackConnect Cloud Servers <accessing-rackconnect-cloud-servers>`.
+  :how-to:`Accessing RackConnect Cloud Servers <accessing-rackconnect-cloud-servers/>`.
 
 - *Does your account use Cloud Monitoring?*
 

--- a/cloud-preprod/scaling.rst
+++ b/cloud-preprod/scaling.rst
@@ -12,4 +12,4 @@ workload.
 Auto Scale relies on Cloud Monitoring and Cloud Load Balancers. To learn
 how to use Auto Scale through the Cloud Control Panel or the Cloud
 Monitoring API, start at the
-:how-to:`Rackspace Auto Scale introduction page <rackspace-auto-scale>`.
+:how-to:`Rackspace Auto Scale introduction page <rackspace-auto-scale/>`.

--- a/cloud-preprod/security.rst
+++ b/cloud-preprod/security.rst
@@ -8,7 +8,7 @@ center, configure it to disable abuse and enable your
 legitimate work. You might need to do some research to identify the
 specific steps required to secure your configuration, but the steps
 should be similar to those shown in
-:how-to:`Basic Cloud Server Security <basic-cloud-server-security>`,
+:how-to:`Basic Cloud Server Security <basic-cloud-server-security/>`,
 which demonstrates the process of securing a cloud server running
 Ubuntu. For that server, the steps are as follows:
 

--- a/cloud-preprod/stack.rst
+++ b/cloud-preprod/stack.rst
@@ -20,9 +20,9 @@ this multi-step process, perform the following actions:
 
 * Read the following articles about LAMP stacks:
 
-  * :how-to:`How to Install a LAMP stack on CentOS, Fedora, or Red Hat <how-to-install-a-lamp-stack-on-centos-fedora-or-red-hat>`
+  * :how-to:`How to Install a LAMP stack on CentOS, Fedora, or Red Hat <how-to-install-a-lamp-stack-on-centos-fedora-or-red-hat/>`
 
-  * :how-to:`Migrating an Application Built on a LAMP Stack from Amazon Web Services <migrating-an-application-built-on-a-lamp-stack-from-amazon-web-services>`
+  * :how-to:`Migrating an Application Built on a LAMP Stack from Amazon Web Services <migrating-an-application-built-on-a-lamp-stack-from-amazon-web-services/>`
 
 * Complete the Cloud Launch Guide tutorial for
   `CMS with WordPress <https://launch.rackspace.com/guides/wordpress>`__

--- a/conf.py
+++ b/conf.py
@@ -105,7 +105,7 @@ extlinks = {
     'rax-api': ('http://api.rackspace.com/%s', ''),
     'rax-git': ('https://github.com/rackspace/%s', ''),
     'mycloud': ('https://mycloud.rackspace.com/%s', ''),
-    'how-to': ('http://www.support.rackspace.com/how-to/%s', ''),
+    'how-to': ('http://support.rackspace.com/how-to/%s', ''),
     'os': ('http://www.openstack.org/%s', ''),
     'os-docs': ('http://docs.openstack.org/%s', ''),
     'os-wiki': ('http://wiki.openstack.org/%s', ''),

--- a/conf.py
+++ b/conf.py
@@ -105,7 +105,7 @@ extlinks = {
     'rax-api': ('http://api.rackspace.com/%s', ''),
     'rax-git': ('https://github.com/rackspace/%s', ''),
     'mycloud': ('https://mycloud.rackspace.com/%s', ''),
-    'how-to': ('http://support.rackspace.com/how-to/%s', ''),
+    'how-to': ('https://support.rackspace.com/how-to/%s', ''),
     'os': ('http://www.openstack.org/%s', ''),
     'os-docs': ('http://docs.openstack.org/%s', ''),
     'os-wiki': ('http://wiki.openstack.org/%s', ''),


### PR DESCRIPTION
~~After switching How-To to using Jekyll and the permalinks, links outside of the how-to repo need to have the trailing slash at the end of the URL.~~

~~This PR adds the trailing slash to all how-to links throughout the guide.~~

The how-to extlink contains a 'www' in the URL path, which is actually causing the problem. I'll let the trailing slashes stay because they aren't hurting anything, but the 'www' is gone!

fixes #421