### PR TITLE
Reference main page by its absolute URL

### DIFF
--- a/_toc.rst
+++ b/_toc.rst
@@ -2,7 +2,7 @@
    :includehidden:
    :maxdepth: 99
 
-   Cloud Core Infrastructure User Guide <self>
+   Cloud Core Infrastructure User Guide <https://developer.rackspace.com/docs/user-guides/infrastructure/>
    cloud-guide-intro/index
    cloud-intro/index
    cloud-interfaces/index


### PR DESCRIPTION
DO NOT MERGE until https://github.com/deconst/presenter/pull/121 is merged and deployed.

Fixes #408.

This is not really in the "deconst spirit" because it assumes we know where our document will be presented. But for this case, and until the improved TOC handling is shipped, it will at least resolve the issue.