### PR TITLE
Fix dead link 

### DIFF
--- a/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
+++ b/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
@@ -29,6 +29,6 @@ Cloud Networks API documentation under
 
 To learn more about security groups, read
 :how-to:`Security groups FAQ <cloud-networks-faq>` and
-:rax-docs:`Use security groups to control traffic <networks/api/v2/cn-gettingstarted/content/security_groups.html>`.
+:rax-docs:`Use security groups to control traffic <cloud-networks/v2/getting-started/controlling-network-access/security-groups>`.
 
 .. include:: /_common/seealso-concepts-cloud-networks.txt

--- a/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
+++ b/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
@@ -25,7 +25,7 @@ are listed in
 You can read full details about API operations
 related to security groups in the
 Cloud Networks API documentation under
-:ref:`Security groups operations (https://developer.rackspace.com/docs/cloud-networks/v2/api-reference/sec-group-operations/)`_.
+`Security groups operations <https://developer.rackspace.com/docs/cloud-networks/v2/api-reference/sec-group-operations/>`__.
 
 To learn more about security groups, read
 :how-to:`Security groups FAQ <cloud-networks-faq>` and

--- a/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
+++ b/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
@@ -25,7 +25,7 @@ are listed in
 You can read full details about API operations
 related to security groups in the
 Cloud Networks API documentation under
-:rax-dev-devguide:`Security groups operations <cloud-networks/v2/developer-guide/#document-api-operations/sec-group-operations>`.
+:ref:`Security groups operations (https://developer.rackspace.com/docs/cloud-networks/v2/api-reference/sec-group-operations/)`_.
 
 To learn more about security groups, read
 :how-to:`Security groups FAQ <cloud-networks-faq>` and

--- a/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
+++ b/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
@@ -25,7 +25,7 @@ are listed in
 You can read full details about API operations
 related to security groups in the
 Cloud Networks API documentation under
-`Security groups operations <https://developer.rackspace.com/docs/cloud-networks/v2/api-reference/sec-group-operations/>`__.
+`Security groups operations <https://developer.rackspace.com/docs/cloud-networks/v2/api-reference/sec-group-operations>`__.
 
 To learn more about security groups, read
 :how-to:`Security groups FAQ <cloud-networks-faq>` and


### PR DESCRIPTION
Fix dead link to "Controlling network traffic by using security groups and rules" document