### PR TITLE
Update security-groups.rst

### DIFF
--- a/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
+++ b/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
@@ -3,7 +3,6 @@
 ~~~~~~~~~~~~~~~
 Security groups
 ~~~~~~~~~~~~~~~
-.. include:: /_common/note-limitedaccess-securitygroups.txt
 
 A security group is a named container for security group rules.
 Security group rules provide Rackspace Public Cloud users the ability
@@ -12,7 +11,7 @@ through, to, and from ports
 (Public/ServiceNet)
 on a cloud server.
 
-Security groups are not yet available through the Cloud Control Panel.
+Security groups are available to all customers through the Cloud Control Panel.
 To work with security groups now,
 use the
 :ref:`neutron CLI <neutron>`

--- a/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
+++ b/cloud-config/network/cloud-networks-product-concepts/security-groups.rst
@@ -11,8 +11,10 @@ through, to, and from ports
 (Public/ServiceNet)
 on a cloud server.
 
-Security groups are available to all customers through the Cloud Control Panel.
-To work with security groups now,
+Security groups are available to all customers through the Cloud
+Control Panel.
+
+To work with security groups,
 use the
 :ref:`neutron CLI <neutron>`
 or


### PR DESCRIPTION
Updated requested:

Looks like this link has some nearly outdated info: https://developer.rackspace.com/docs/user-guides/infrastructure/cloud-config/network/cloud-networks-product-concepts/security-groups/#security-groups
 
This week SGs should be available to all customers in the control panel so we should indicate that!  Thanks!