### PR TITLE
Waldo change - Remove image from control panel

### DIFF
--- a/cloud-config/compute/cloud-servers-product-concepts/server-region.rst
+++ b/cloud-config/compute/cloud-servers-product-concepts/server-region.rst
@@ -56,12 +56,7 @@ transfer time.
 
 Choose an image that supports the applications you intend to run.
 
-.. figure:: /_images/cloudservercreateimageubuntu.png
-   :alt: Choose an operating system.
-         Your choice can affect your cost.
-
-   *Choose an operating system.
-   Your choice can affect your cost.*
+Choose an operating system. Your choice can affect your cost.
 
 **Step 3: Flavor**
 


### PR DESCRIPTION
That shows logo with Ubuntu.
This change is suggested by legal. When control panel is changed, consider putting in new image from control panel.